### PR TITLE
Remove pixiRunShell variable

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -61051,7 +61051,6 @@ var inferOptions = (inputs) => {
   const pixiLockFile = import_path.default.join(import_path.default.dirname(manifestPath), import_path.default.basename(manifestPath).replace(/\.toml$/, ".lock"));
   const cache2 = inputs.cacheKey ? { cacheKeyPrefix: inputs.cacheKey, cacheWrite: inputs.cacheWrite ?? true } : inputs.cache ? { cacheKeyPrefix: "pixi-", cacheWrite: true } : void 0;
   const pixiBinPath = inputs.pixiBinPath ? import_path.default.resolve(untildify(inputs.pixiBinPath)) : PATHS.pixiBin;
-  const pixiRunShell = import_path.default.join(import_path.default.dirname(pixiBinPath), "pixi-shell");
   const frozen = inputs.frozen ?? false;
   const lockFileAvailable = (0, import_fs.existsSync)(pixiLockFile);
   core.debug(`lockFileAvailable: ${lockFileAvailable}`);
@@ -61078,7 +61077,6 @@ var inferOptions = (inputs) => {
     locked,
     cache: cache2,
     pixiBinPath,
-    pixiRunShell,
     auth,
     postCleanup
   };

--- a/dist/post.js
+++ b/dist/post.js
@@ -5918,7 +5918,6 @@ var inferOptions = (inputs) => {
   const pixiLockFile = import_path.default.join(import_path.default.dirname(manifestPath), import_path.default.basename(manifestPath).replace(/\.toml$/, ".lock"));
   const cache = inputs.cacheKey ? { cacheKeyPrefix: inputs.cacheKey, cacheWrite: inputs.cacheWrite ?? true } : inputs.cache ? { cacheKeyPrefix: "pixi-", cacheWrite: true } : void 0;
   const pixiBinPath = inputs.pixiBinPath ? import_path.default.resolve(untildify(inputs.pixiBinPath)) : PATHS.pixiBin;
-  const pixiRunShell = import_path.default.join(import_path.default.dirname(pixiBinPath), "pixi-shell");
   const frozen = inputs.frozen ?? false;
   const lockFileAvailable = (0, import_fs.existsSync)(pixiLockFile);
   core.debug(`lockFileAvailable: ${lockFileAvailable}`);
@@ -5945,7 +5944,6 @@ var inferOptions = (inputs) => {
     locked,
     cache,
     pixiBinPath,
-    pixiRunShell,
     auth,
     postCleanup
   };

--- a/src/options.ts
+++ b/src/options.ts
@@ -64,7 +64,6 @@ export type Options = Readonly<{
   locked: boolean
   cache?: Cache
   pixiBinPath: string
-  pixiRunShell: string
   auth?: Auth
   postCleanup: boolean
 }>
@@ -161,7 +160,6 @@ const inferOptions = (inputs: Inputs): Options => {
     ? { cacheKeyPrefix: 'pixi-', cacheWrite: true }
     : undefined
   const pixiBinPath = inputs.pixiBinPath ? path.resolve(untildify(inputs.pixiBinPath)) : PATHS.pixiBin
-  const pixiRunShell = path.join(path.dirname(pixiBinPath), 'pixi-shell')
   const frozen = inputs.frozen ?? false
   const lockFileAvailable = existsSync(pixiLockFile)
   core.debug(`lockFileAvailable: ${lockFileAvailable}`)
@@ -194,7 +192,6 @@ const inferOptions = (inputs: Inputs): Options => {
     locked,
     cache,
     pixiBinPath,
-    pixiRunShell,
     auth,
     postCleanup
   }


### PR DESCRIPTION
This variable was never used because you can just use `shell: pixi run bash {0}`