### PR TITLE
fix: respect frozen/locked inputs for pixi list

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -182,7 +182,7 @@ jobs:
         with:
           cache: false
           pixi-url: https://github.com/prefix-dev/pixi/releases/download/v0.14.0/pixi-x86_64-unknown-linux-musl
-      - run: pixi --version | grep -q "pixi 0.13.0"
+      - run: pixi --version | grep -q "pixi 0.14.0"
 
   custom-manifest-path:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -181,7 +181,7 @@ jobs:
       - uses: ./
         with:
           cache: false
-          pixi-url: https://github.com/prefix-dev/pixi/releases/download/v0.13.0/pixi-x86_64-unknown-linux-musl
+          pixi-url: https://github.com/prefix-dev/pixi/releases/download/v0.14.0/pixi-x86_64-unknown-linux-musl
       - run: pixi --version | grep -q "pixi 0.13.0"
 
   custom-manifest-path:

--- a/dist/index.js
+++ b/dist/index.js
@@ -78874,14 +78874,14 @@ var generateList = async () => {
     );
     return Promise.resolve();
   }
-  var command = "list";
+  let command = "list";
   if ("version" in options.pixiSource && options.pixiSource.version !== "latest" && options.pixiSource.version < "v0.14.0") {
     if (options.frozen)
       core4.warning("pixi versions < `v0.14.0` do not support the --frozen option for pixi list.");
     if (options.locked)
       core4.warning("pixi versions < `v0.14.0` do not support the --locked option for pixi list.");
   } else {
-    command = `${command} ${options.frozen ? "--frozen" : ""} ${options.locked ? "--locked" : ""}`;
+    command = `${command}${options.frozen ? " --frozen" : ""}${options.locked ? " --locked" : ""}`;
   }
   if (options.environments) {
     for (const environment of options.environments) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -78874,14 +78874,15 @@ var generateList = async () => {
     );
     return Promise.resolve();
   }
+  const command = "version" in options.pixiSource && options.pixiSource.version !== "latest" && options.pixiSource.version < "v0.14.0" ? "list" : `list${options.frozen ? " --frozen" : ""}${options.locked ? " --locked" : ""}`;
   if (options.environments) {
     for (const environment of options.environments) {
       core4.debug(`Listing environment ${environment}`);
-      await core4.group(`pixi list -e ${environment}`, () => execute(pixiCmd(`list -e ${environment}`)));
+      await core4.group(`pixi ${command} -e ${environment}`, () => execute(pixiCmd(`${command} -e ${environment}`)));
     }
     return Promise.resolve();
   } else {
-    return core4.group("pixi list", () => execute(pixiCmd("list")));
+    return core4.group(`pixi ${command}`, () => execute(pixiCmd(command)));
   }
 };
 var generateInfo = () => core4.group("pixi info", () => execute(pixiCmd("info")));

--- a/dist/index.js
+++ b/dist/index.js
@@ -78874,7 +78874,15 @@ var generateList = async () => {
     );
     return Promise.resolve();
   }
-  const command = "version" in options.pixiSource && options.pixiSource.version !== "latest" && options.pixiSource.version < "v0.14.0" ? "list" : `list${options.frozen ? " --frozen" : ""}${options.locked ? " --locked" : ""}`;
+  var command = "list";
+  if ("version" in options.pixiSource && options.pixiSource.version !== "latest" && options.pixiSource.version < "v0.14.0") {
+    if (options.frozen)
+      core4.warning("pixi versions < `v0.14.0` do not support the --frozen option for pixi list.");
+    if (options.locked)
+      core4.warning("pixi versions < `v0.14.0` do not support the --locked option for pixi list.");
+  } else {
+    command = `${command} ${options.frozen ? "--frozen" : ""} ${options.locked ? "--locked" : ""}`;
+  }
   if (options.environments) {
     for (const environment of options.environments) {
       core4.debug(`Listing environment ${environment}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -58,9 +58,8 @@ const pixiInstall = async () => {
       if (options.environments) {
         for (const environment of options.environments) {
           core.debug(`Installing environment ${environment}`)
-          const command = `install -e ${environment}${options.frozen ? ' --frozen' : ''}${
-            options.locked ? ' --locked' : ''
-          }`
+          const command = `install -e ${environment}${options.frozen ? ' --frozen' : ''}${options.locked ? ' --locked' : ''
+            }`
           await core.group(`pixi ${command}`, () => execute(pixiCmd(command)))
         }
       } else {
@@ -86,14 +85,20 @@ const generateList = async () => {
     )
     return Promise.resolve()
   }
+  const command = (
+    'version' in options.pixiSource &&
+    options.pixiSource.version !== 'latest' &&
+    options.pixiSource.version < 'v0.14.0')
+    ? 'list'
+    : `list${options.frozen ? ' --frozen' : ''}${options.locked ? ' --locked' : ''}`
   if (options.environments) {
     for (const environment of options.environments) {
       core.debug(`Listing environment ${environment}`)
-      await core.group(`pixi list -e ${environment}`, () => execute(pixiCmd(`list -e ${environment}`)))
+      await core.group(`pixi ${command} -e ${environment}`, () => execute(pixiCmd(`${command} -e ${environment}`)))
     }
     return Promise.resolve()
   } else {
-    return core.group('pixi list', () => execute(pixiCmd('list')))
+    return core.group(`pixi ${command}`, () => execute(pixiCmd(command)))
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -85,12 +85,17 @@ const generateList = async () => {
     )
     return Promise.resolve()
   }
-  const command = (
+  var command = 'list'
+  if (
     'version' in options.pixiSource &&
     options.pixiSource.version !== 'latest' &&
-    options.pixiSource.version < 'v0.14.0')
-    ? 'list'
-    : `list${options.frozen ? ' --frozen' : ''}${options.locked ? ' --locked' : ''}`
+    options.pixiSource.version < 'v0.14.0'
+  ) {
+    if (options.frozen) core.warning('pixi versions < `v0.14.0` do not support the --frozen option for pixi list.')
+    if (options.locked) core.warning('pixi versions < `v0.14.0` do not support the --locked option for pixi list.')
+  } else {
+    command = `${command} ${options.frozen ? '--frozen' : ''} ${options.locked ? '--locked' : ''}`
+  }
   if (options.environments) {
     for (const environment of options.environments) {
       core.debug(`Listing environment ${environment}`)

--- a/src/main.ts
+++ b/src/main.ts
@@ -58,8 +58,9 @@ const pixiInstall = async () => {
       if (options.environments) {
         for (const environment of options.environments) {
           core.debug(`Installing environment ${environment}`)
-          const command = `install -e ${environment}${options.frozen ? ' --frozen' : ''}${options.locked ? ' --locked' : ''
-            }`
+          const command = `install -e ${environment}${options.frozen ? ' --frozen' : ''}${
+            options.locked ? ' --locked' : ''
+          }`
           await core.group(`pixi ${command}`, () => execute(pixiCmd(command)))
         }
       } else {
@@ -85,7 +86,7 @@ const generateList = async () => {
     )
     return Promise.resolve()
   }
-  var command = 'list'
+  let command = 'list'
   if (
     'version' in options.pixiSource &&
     options.pixiSource.version !== 'latest' &&
@@ -94,7 +95,7 @@ const generateList = async () => {
     if (options.frozen) core.warning('pixi versions < `v0.14.0` do not support the --frozen option for pixi list.')
     if (options.locked) core.warning('pixi versions < `v0.14.0` do not support the --locked option for pixi list.')
   } else {
-    command = `${command} ${options.frozen ? '--frozen' : ''} ${options.locked ? '--locked' : ''}`
+    command = `${command}${options.frozen ? ' --frozen' : ''}${options.locked ? ' --locked' : ''}`
   }
   if (options.environments) {
     for (const environment of options.environments) {


### PR DESCRIPTION
This action runs the following sequnce

1) `pixi install ...`
2) `pixi info ...`
3) `pixi list ...`

Running `pixi list` without `--frozen` or `--locked` will try to update dependencies and lockfile. I think these options need to be passed through to `pixi list`  to keep the environment established by a locked or frozen install from changing.