### PR TITLE
Improve `run-install` wording

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
   manifest-path:
     description: Path to the manifest file (i.e., `pixi.toml`) to use for the pixi CLI. Defaults to `pixi.toml`.
   run-install:
-    description: Whether to run `pixi install` after setting up the environment. Defaults to `true`.
+    description: Whether to run `pixi install` after installing pixi. Defaults to `true`.
   environments:
     description: |
       A space-separated list of environments to install. If not specified, only the default environment is installed.


### PR DESCRIPTION
"setting up environment" can be confused with "creating the pixi conda environment"

---


If updating documentation:

- [x] Updated documentation in https://github.com/prefix-dev/pixi/blob/main/docs/advanced/github_actions.md as well (not relevant)


