### PR TITLE
feat: Allow to retry pixi install

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ GitHub Action to set up the [pixi](https://github.com/prefix-dev/pixi) package m
 ```yml
 - uses: prefix-dev/setup-pixi@v0.8.1
   with:
-    pixi-version: v0.33.0
+    pixi-version: v0.34.0
     cache: true
     auth-host: prefix.dev
     auth-token: ${{ secrets.PREFIX_DEV_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,8 @@ inputs:
     description: Password to use for authentication.
   auth-conda-token:
     description: Conda token to use for authentication.
+  retry-count:
+    description: The number of times the action should retry installing packages if an error occurs.
   post-cleanup:
     description: |
       If the action should clean up after itself. Defaults to `true`.

--- a/dist/index.js
+++ b/dist/index.js
@@ -65439,13 +65439,16 @@ var run = async () => {
   }
   addPixiToPath();
   await pixiLogin();
-  await (0, import_async_retry.default)(async () => {
-    await pixiInstall();
-  }, {
-    retries: options.retryCount,
-    minTimeout: 5e3,
-    randomize: true
-  });
+  await (0, import_async_retry.default)(
+    async () => {
+      await pixiInstall();
+    },
+    {
+      retries: options.retryCount,
+      minTimeout: 5e3,
+      randomize: true
+    }
+  );
   await generateInfo();
   await generateList();
   if (options.activatedEnvironment) {

--- a/dist/post.js
+++ b/dist/post.js
@@ -25168,6 +25168,9 @@ var validateInputs = (inputs) => {
   if (inputs.activateEnvironment === "true" && inputs.environments && inputs.environments.length > 1) {
     throw new Error("When installing multiple environments, `activate-environment` must specify the environment name");
   }
+  if (inputs.retryCount && inputs.retryCount < 0) {
+    throw new Error("Retry count must be non-negative");
+  }
 };
 var determinePixiInstallation = (pixiUrlOrVersionSet, pixiBinPath) => {
   const preinstalledPixi = import_which.default.sync("pixi", { nothrow: true });
@@ -25246,6 +25249,7 @@ var inferOptions = (inputs) => {
     username: inputs.authUsername,
     password: inputs.authPassword
   };
+  const retryCount = inputs.retryCount ?? 0;
   const postCleanup = inputs.postCleanup ?? true;
   return {
     pixiSource,
@@ -25261,6 +25265,7 @@ var inferOptions = (inputs) => {
     cache,
     pixiBinPath,
     auth,
+    retryCount,
     postCleanup
   };
 };
@@ -25294,6 +25299,7 @@ var getOptions = () => {
     authUsername: parseOrUndefined("auth-username", stringType()),
     authPassword: parseOrUndefined("auth-password", stringType()),
     authCondaToken: parseOrUndefined("auth-conda-token", stringType()),
+    retryCount: parseOrUndefined("retry-count", numberType()),
     postCleanup: parseOrUndefinedJSON("post-cleanup", booleanType())
   };
   core.debug(`Inputs: ${JSON.stringify(inputs)}`);

--- a/package.json
+++ b/package.json
@@ -28,12 +28,14 @@
     "@actions/io": "^1.1.3",
     "@actions/tool-cache": "^2.0.1",
     "@iarna/toml": "^2.2.5",
+    "async-retry": "^1.3.3",
     "untildify": "^5.0.0",
     "which": "^4.0.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",
+    "@types/async-retry": "^1.4.9",
     "@types/eslint__js": "^8.42.3",
     "@types/node": "^22.5.1",
     "@types/which": "^3.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@iarna/toml':
         specifier: ^2.2.5
         version: 2.2.5
+      async-retry:
+        specifier: ^1.3.3
+        version: 1.3.3
       untildify:
         specifier: ^5.0.0
         version: 5.0.0
@@ -39,6 +42,9 @@ importers:
       '@eslint/js':
         specifier: ^9.9.1
         version: 9.9.1
+      '@types/async-retry':
+        specifier: ^1.4.9
+        version: 1.4.9
       '@types/eslint__js':
         specifier: ^8.42.3
         version: 8.42.3
@@ -445,6 +451,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@types/async-retry@1.4.9':
+    resolution: {integrity: sha512-s1ciZQJzRh3708X/m3vPExr5KJlzlZJvXsKpbtE2luqNcbROr64qU+3KpJsYHqWMeaxI839OvXf9PrUSw1Xtyg==}
+
   '@types/eslint@9.6.1':
     resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
 
@@ -459,6 +468,9 @@ packages:
 
   '@types/node@22.5.1':
     resolution: {integrity: sha512-KkHsxej0j9IW1KKOOAA/XBA0z08UFSrRQHErzEfA3Vgq57eXIMYboIlHJuYIfd+lwCQjtKqUu3UnmKbtUc9yRw==}
+
+  '@types/retry@0.12.5':
+    resolution: {integrity: sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==}
 
   '@types/which@3.0.4':
     resolution: {integrity: sha512-liyfuo/106JdlgSchJzXEQCVArk0CvevqPote8F8HgWgJ3dRCcTHgJIsLDuee0kxk/mhbInzIZk3QWSZJ8R+2w==}
@@ -570,6 +582,9 @@ packages:
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
+
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -1083,6 +1098,10 @@ packages:
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
 
   reusify@1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
@@ -1676,6 +1695,10 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.21.1':
     optional: true
 
+  '@types/async-retry@1.4.9':
+    dependencies:
+      '@types/retry': 0.12.5
+
   '@types/eslint@9.6.1':
     dependencies:
       '@types/estree': 1.0.5
@@ -1692,6 +1715,8 @@ snapshots:
   '@types/node@22.5.1':
     dependencies:
       undici-types: 6.19.8
+
+  '@types/retry@0.12.5': {}
 
   '@types/which@3.0.4': {}
 
@@ -1819,6 +1844,10 @@ snapshots:
   argparse@2.0.1: {}
 
   array-union@2.1.0: {}
+
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
 
   asynckit@0.4.0: {}
 
@@ -2308,6 +2337,8 @@ snapshots:
   resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
+
+  retry@0.13.1: {}
 
   reusify@1.0.4: {}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import * as core from '@actions/core'
 import { downloadTool } from '@actions/tool-cache'
 import type { PixiSource } from './options'
 import { options } from './options'
+import retry from 'async-retry';
 import { execute, getPixiUrlFromVersion, pixiCmd } from './util'
 import { saveCache, tryRestoreCache } from './cache'
 import { activateEnvironment } from './activate'
@@ -123,7 +124,11 @@ const run = async () => {
   }
   addPixiToPath()
   await pixiLogin()
-  await pixiInstall()
+  await retry(async () => { await pixiInstall() }, {
+    retries: options.retryCount,
+    minTimeout: 5000,
+    randomize: true
+  })
   await generateInfo()
   await generateList()
   if (options.activatedEnvironment) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ import * as core from '@actions/core'
 import { downloadTool } from '@actions/tool-cache'
 import type { PixiSource } from './options'
 import { options } from './options'
-import retry from 'async-retry';
+import retry from 'async-retry'
 import { execute, getPixiUrlFromVersion, pixiCmd } from './util'
 import { saveCache, tryRestoreCache } from './cache'
 import { activateEnvironment } from './activate'
@@ -124,11 +124,16 @@ const run = async () => {
   }
   addPixiToPath()
   await pixiLogin()
-  await retry(async () => { await pixiInstall() }, {
-    retries: options.retryCount,
-    minTimeout: 5000,
-    randomize: true
-  })
+  await retry(
+    async () => {
+      await pixiInstall()
+    },
+    {
+      retries: options.retryCount,
+      minTimeout: 5000,
+      randomize: true
+    }
+  )
   await generateInfo()
   await generateList()
   if (options.activatedEnvironment) {

--- a/src/options.ts
+++ b/src/options.ts
@@ -27,7 +27,7 @@ type Inputs = Readonly<{
   authUsername?: string
   authPassword?: string
   authCondaToken?: string
-  retryCount?: number,
+  retryCount?: number
   postCleanup?: boolean
 }>
 
@@ -72,7 +72,7 @@ export type Options = Readonly<{
   cache?: Cache
   pixiBinPath: string
   auth?: Auth
-  retryCount: number,
+  retryCount: number
   postCleanup: boolean
   activatedEnvironment?: string
 }>

--- a/src/options.ts
+++ b/src/options.ts
@@ -27,6 +27,7 @@ type Inputs = Readonly<{
   authUsername?: string
   authPassword?: string
   authCondaToken?: string
+  retryCount?: number,
   postCleanup?: boolean
 }>
 
@@ -71,6 +72,7 @@ export type Options = Readonly<{
   cache?: Cache
   pixiBinPath: string
   auth?: Auth
+  retryCount: number,
   postCleanup: boolean
   activatedEnvironment?: string
 }>
@@ -165,6 +167,9 @@ const validateInputs = (inputs: Inputs): void => {
   }
   if (inputs.activateEnvironment === 'true' && inputs.environments && inputs.environments.length > 1) {
     throw new Error('When installing multiple environments, `activate-environment` must specify the environment name')
+  }
+  if (inputs.retryCount && inputs.retryCount < 0) {
+    throw new Error('Retry count must be non-negative')
   }
 }
 
@@ -268,6 +273,7 @@ const inferOptions = (inputs: Inputs): Options => {
               username: inputs.authUsername,
               password: inputs.authPassword
             }) as Auth)
+  const retryCount = inputs.retryCount ?? 0
   const postCleanup = inputs.postCleanup ?? true
   return {
     pixiSource,
@@ -283,6 +289,7 @@ const inferOptions = (inputs: Inputs): Options => {
     cache,
     pixiBinPath,
     auth,
+    retryCount,
     postCleanup
   }
 }
@@ -324,6 +331,7 @@ const getOptions = () => {
     authUsername: parseOrUndefined('auth-username', z.string()),
     authPassword: parseOrUndefined('auth-password', z.string()),
     authCondaToken: parseOrUndefined('auth-conda-token', z.string()),
+    retryCount: parseOrUndefined('retry-count', z.number()),
     postCleanup: parseOrUndefinedJSON('post-cleanup', z.boolean())
   }
   core.debug(`Inputs: ${JSON.stringify(inputs)}`)

--- a/tsup.config.js
+++ b/tsup.config.js
@@ -24,6 +24,7 @@ export default defineConfig({
     '@actions/cache',
     '@actions/io',
     '@actions/tool-cache',
+    'async-retry',
     'untildify',
     '@iarna/toml',
     'which',


### PR DESCRIPTION
In some instances, running this action on self-hosted runners in an environment with bad network connection requires retries of `pixi install` regardless of pixi's internal retries. This PR introduces a separate flag `retry-count` which allows to retry this step with exponential backoff.

If updating documentation:

- [ ] Updated documentation in https://github.com/prefix-dev/pixi/blob/main/docs/advanced/github_actions.md as well
