### PR TITLE
fix: Forcefully remove empty parents directory on post-cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ GitHub Action to set up the [pixi](https://github.com/prefix-dev/pixi) package m
 ## Usage
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.9
+- uses: prefix-dev/setup-pixi@v0.8.10
   with:
     pixi-version: v0.44.0
 
@@ -35,7 +35,7 @@ GitHub Action to set up the [pixi](https://github.com/prefix-dev/pixi) package m
 
 > [!WARNING]
 > Since pixi is not yet stable, the API of this action may change between minor versions.
-> Please pin the versions of this action to a specific version (i.e., `prefix-dev/setup-pixi@v0.8.9`) to avoid breaking changes.
+> Please pin the versions of this action to a specific version (i.e., `prefix-dev/setup-pixi@v0.8.10`) to avoid breaking changes.
 > You can automatically update the version of this action by using [Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot).
 >
 > Put the following in your `.github/dependabot.yml` file to enable Dependabot for your GitHub Actions:
@@ -74,7 +74,7 @@ In order to not exceed the [10 GB cache size limit](https://docs.github.com/en/a
 This can be done by setting the `cache-write` argument.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.9
+- uses: prefix-dev/setup-pixi@v0.8.10
   with:
     cache: true
     cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
@@ -119,7 +119,7 @@ test:
       environment: [py311, py312]
   steps:
     - uses: actions/checkout@v4
-    - uses: prefix-dev/setup-pixi@v0.8.9
+    - uses: prefix-dev/setup-pixi@v0.8.10
       with:
         environments: ${{ matrix.environment }}
 ```
@@ -129,7 +129,7 @@ test:
 The following example will install both the `py311` and the `py312` environment on the runner.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.9
+- uses: prefix-dev/setup-pixi@v0.8.10
   with:
     # separated by spaces
     environments: >-
@@ -165,7 +165,7 @@ Specify the token using the `auth-token` input argument.
 This form of authentication (bearer token in the request headers) is mainly used at [prefix.dev](https://prefix.dev).
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.9
+- uses: prefix-dev/setup-pixi@v0.8.10
   with:
     auth-host: prefix.dev
     auth-token: ${{ secrets.PREFIX_DEV_TOKEN }}
@@ -177,7 +177,7 @@ Specify the username and password using the `auth-username` and `auth-password` 
 This form of authentication (HTTP Basic Auth) is used in some enterprise environments with [artifactory](https://jfrog.com/artifactory) for example.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.9
+- uses: prefix-dev/setup-pixi@v0.8.10
   with:
     auth-host: custom-artifactory.com
     auth-username: ${{ secrets.PIXI_USERNAME }}
@@ -190,7 +190,7 @@ Specify the conda-token using the `auth-conda-token` input argument.
 This form of authentication (token is encoded in URL: `https://my-quetz-instance.com/t/<token>/get/custom-channel`) is used at [anaconda.org](https://anaconda.org) or with [quetz instances](https://github.com/mamba-org/quetz).
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.9
+- uses: prefix-dev/setup-pixi@v0.8.10
   with:
     auth-host: anaconda.org # or my-quetz-instance.com
     auth-conda-token: ${{ secrets.CONDA_TOKEN }}
@@ -202,7 +202,7 @@ Specify the S3 key pair using the `auth-access-key-id` and `auth-secret-access-k
 You can also specify the session token using the `auth-session-token` input argument.
 
 ```yaml
-- uses: prefix-dev/setup-pixi@v0.8.9
+- uses: prefix-dev/setup-pixi@v0.8.10
   with:
     auth-host: s3://my-s3-bucket
     auth-s3-access-key-id: ${{ secrets.ACCESS_KEY_ID }}
@@ -274,7 +274,7 @@ To this end, `setup-pixi` adds all environment variables set when executing `pix
 As a result, all installed binaries can be accessed without having to call `pixi run`.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.9
+- uses: prefix-dev/setup-pixi@v0.8.10
   with:
     activate-environment: true
 ```
@@ -282,7 +282,7 @@ As a result, all installed binaries can be accessed without having to call `pixi
 If you are installing multiple environments, you will need to specify the name of the environment that you want to be activated.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.9
+- uses: prefix-dev/setup-pixi@v0.8.10
   with:
     environments: >-
       py311
@@ -299,7 +299,7 @@ You can specify whether `setup-pixi` should run `pixi install --frozen` or `pixi
 See the [official documentation](https://prefix.dev/docs/pixi/cli#install) for more information about the `--frozen` and `--locked` flags.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.9
+- uses: prefix-dev/setup-pixi@v0.8.10
   with:
     locked: true
     # or
@@ -318,7 +318,7 @@ The first one is the debug logging of the action itself.
 This can be enabled by running the action with the `RUNNER_DEBUG` environment variable set to `true`.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.9
+- uses: prefix-dev/setup-pixi@v0.8.10
   env:
     RUNNER_DEBUG: true
 ```
@@ -336,7 +336,7 @@ The second type is the debug logging of the pixi executable.
 This can be specified by setting the `log-level` input.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.9
+- uses: prefix-dev/setup-pixi@v0.8.10
   with:
     # one of `q`, `default`, `v`, `vv`, or `vvv`.
     log-level: vvv
@@ -362,7 +362,7 @@ If nothing is specified, `post-cleanup` will default to `true`.
 On self-hosted runners, you also might want to alter the default pixi install location to a temporary location. You can use `pixi-bin-path: ${{ runner.temp }}/bin/pixi` to do this.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.9
+- uses: prefix-dev/setup-pixi@v0.8.10
   with:
     post-cleanup: true
     # ${{ runner.temp }}\Scripts\pixi.exe on Windows
@@ -378,7 +378,7 @@ You can also use a preinstalled local version of pixi on the runner by not setti
 This can be overwritten by setting the `manifest-path` input argument.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.9
+- uses: prefix-dev/setup-pixi@v0.8.10
   with:
     manifest-path: pyproject.toml
 ```
@@ -388,7 +388,7 @@ This can be overwritten by setting the `manifest-path` input argument.
 If you only want to install pixi and not install the current project, you can use the `run-install` option.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.9
+- uses: prefix-dev/setup-pixi@v0.8.10
   with:
     run-install: false
 ```

--- a/dist/post.js
+++ b/dist/post.js
@@ -24972,7 +24972,7 @@ var removeEmptyParentDirs = (dirPath) => {
   return import_promises.default.readdir(dirPath).then((files) => {
     if (files.length === 0) {
       core2.debug(`Removing empty directory ${dirPath}.`);
-      return import_promises.default.rm(dirPath, { recursive: true }).then(() => {
+      return import_promises.default.rm(dirPath, { recursive: true, force: true }).then(() => {
         const parentDir = import_path2.default.dirname(dirPath);
         if (parentDir !== dirPath) {
           return removeEmptyParentDirs(parentDir);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-pixi",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "private": true,
   "description": "Action to set up the pixi package manager.",
   "scripts": {

--- a/src/post.ts
+++ b/src/post.ts
@@ -9,7 +9,7 @@ const removeEmptyParentDirs = (dirPath: string): Promise<void> => {
   return fs.readdir(dirPath).then((files) => {
     if (files.length === 0) {
       core.debug(`Removing empty directory ${dirPath}.`)
-      return fs.rm(dirPath, { recursive: true }).then(() => {
+      return fs.rm(dirPath, { recursive: true, force: true }).then(() => {
         const parentDir = path.dirname(dirPath)
         if (parentDir !== dirPath) {
           return removeEmptyParentDirs(parentDir)


### PR DESCRIPTION
Forgot to add `force: true` in one place in #204.

If updating documentation:

- [ ] Updated documentation in https://github.com/prefix-dev/pixi/blob/main/docs/integration/ci/github_actions.md as well
