### PR TITLE
feat: Add `pixi-url-bearer-token` to authenticate when downloading from `pixi-url`

### DIFF
--- a/.github/assets/pixi-url-auth-test/Caddyfile
+++ b/.github/assets/pixi-url-auth-test/Caddyfile
@@ -1,0 +1,7 @@
+:8080 {
+	@unauthorized not header Authorization "Bearer s3cr3tT0k3nABC123"
+	respond @unauthorized "Unauthorized: Invalid token" 401
+
+	root * ./assets
+	file_server
+}

--- a/.github/assets/pixi-url-auth-test/Caddyfile
+++ b/.github/assets/pixi-url-auth-test/Caddyfile
@@ -1,7 +1,7 @@
 :8080 {
-	@unauthorized not header Authorization "Bearer s3cr3tT0k3nABC123"
-	respond @unauthorized "Unauthorized: Invalid token" 401
+    @unauthorized not header Authorization "Bearer s3cr3tT0k3nABC123"
+    respond @unauthorized "Unauthorized: Invalid token" 401
 
-	root * ./assets
-	file_server
+    root * ./assets
+    file_server
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           set -euo pipefail
           latest_version="$(jq -r '.version' package.json)"
-          count_expected=17
+          count_expected=18
           count_actual="$(grep -c "setup-pixi@v$latest_version" README.md || true)"
           if [ "$count_actual" -ne "$count_expected" ]; then
             echo "::error file=README.md::Expected $count_expected mentions of \`setup-pixi@v$latest_version\` in README.md, but found $count_actual."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -190,6 +190,45 @@ jobs:
           pixi-url: https://github.com/prefix-dev/pixi/releases/download/v0.14.0/pixi-x86_64-unknown-linux-musl
       - run: pixi --version | grep -q "pixi 0.14.0"
 
+  pixi-url-bearer-token:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Move pixi.toml
+        run: mv test/old-pixi-lockfiles/* .
+      - name: Setup caddy
+        run: |
+          set -euo pipefail
+          curl -Ls -o caddy.tar.gz https://github.com/caddyserver/caddy/releases/download/v2.10.0/caddy_2.10.0_linux_amd64.tar.gz
+          tar -xzf caddy.tar.gz
+          chmod +x caddy
+
+          mkdir -p assets
+          curl -Ls -o assets/pixi https://github.com/prefix-dev/pixi/releases/download/v0.14.0/pixi-x86_64-unknown-linux-musl
+
+          cp .github/assets/pixi-url-auth-test/Caddyfile .
+
+          ./caddy run --config Caddyfile &
+      - run: ps -aux | grep caddy
+      - uses: ./
+        id: wrongtoken
+        with:
+          cache: false
+          pixi-url: http://localhost:8080/pixi
+          pixi-url-bearer-token: wrongtoken
+        continue-on-error: true
+      - name: Fail if wrong token did not fail
+        run: |
+          echo "Unexpected success!"
+          exit 1
+        if: ${{ steps.wrongtoken.outcome != 'failure' }}
+      - uses: ./
+        with:
+          cache: false
+          pixi-url: http://localhost:8080/pixi
+          pixi-url-bearer-token: s3cr3tT0k3nABC123
+      - run: pixi --version | grep -q "pixi 0.14.0"
+
   custom-manifest-path:
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,7 +210,8 @@ jobs:
 
           ./caddy run --config Caddyfile &
       - run: ps -aux | grep caddy
-      - uses: ./
+      - name: Run with wrong token
+        uses: ./
         id: wrongtoken
         with:
           cache: false
@@ -222,7 +223,8 @@ jobs:
           echo "Unexpected success!"
           exit 1
         if: ${{ steps.wrongtoken.outcome != 'failure' }}
-      - uses: ./
+      - name: Run with correct token
+        uses: ./
         with:
           cache: false
           pixi-url: http://localhost:8080/pixi

--- a/README.md
+++ b/README.md
@@ -393,6 +393,18 @@ If you only want to install pixi and not install the current project, you can us
     run-install: false
 ```
 
+### Download pixi from a custom URL
+
+You can also download pixi from a custom URL by setting the `pixi-url` input argument.
+Optionally, you can combine this with the `pixi-url-bearer-token` input argument to authenticate the download request.
+
+```yml
+- uses: prefix-dev/setup-pixi@v0.8.10
+  with:
+    pixi-url: https://pixi-mirror.example.com/releases/download/v0.48.0/pixi-x86_64-unknown-linux-musl
+    pixi-url-bearer-token: ${{ secrets.PIXI_MIRROR_BEARER_TOKEN }}
+```
+
 ## More examples
 
 If you want to see more examples, you can take a look at the [GitHub Workflows of this repository](.github/workflows/test.yml).

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ GitHub Action to set up the [pixi](https://github.com/prefix-dev/pixi) package m
 ## Usage
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.10
+- uses: prefix-dev/setup-pixi@v0.8.11
   with:
     pixi-version: v0.49.0
 
@@ -35,7 +35,7 @@ GitHub Action to set up the [pixi](https://github.com/prefix-dev/pixi) package m
 
 > [!WARNING]
 > Since pixi is not yet stable, the API of this action may change between minor versions.
-> Please pin the versions of this action to a specific version (i.e., `prefix-dev/setup-pixi@v0.8.10`) to avoid breaking changes.
+> Please pin the versions of this action to a specific version (i.e., `prefix-dev/setup-pixi@v0.8.11`) to avoid breaking changes.
 > You can automatically update the version of this action by using [Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot).
 >
 > Put the following in your `.github/dependabot.yml` file to enable Dependabot for your GitHub Actions:
@@ -74,7 +74,7 @@ In order to not exceed the [10 GB cache size limit](https://docs.github.com/en/a
 This can be done by setting the `cache-write` argument.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.10
+- uses: prefix-dev/setup-pixi@v0.8.11
   with:
     cache: true
     cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
@@ -119,7 +119,7 @@ test:
       environment: [py311, py312]
   steps:
     - uses: actions/checkout@v4
-    - uses: prefix-dev/setup-pixi@v0.8.10
+    - uses: prefix-dev/setup-pixi@v0.8.11
       with:
         environments: ${{ matrix.environment }}
 ```
@@ -129,7 +129,7 @@ test:
 The following example will install both the `py311` and the `py312` environment on the runner.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.10
+- uses: prefix-dev/setup-pixi@v0.8.11
   with:
     # separated by spaces
     environments: >-
@@ -165,7 +165,7 @@ Specify the token using the `auth-token` input argument.
 This form of authentication (bearer token in the request headers) is mainly used at [prefix.dev](https://prefix.dev).
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.10
+- uses: prefix-dev/setup-pixi@v0.8.11
   with:
     auth-host: prefix.dev
     auth-token: ${{ secrets.PREFIX_DEV_TOKEN }}
@@ -177,7 +177,7 @@ Specify the username and password using the `auth-username` and `auth-password` 
 This form of authentication (HTTP Basic Auth) is used in some enterprise environments with [artifactory](https://jfrog.com/artifactory) for example.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.10
+- uses: prefix-dev/setup-pixi@v0.8.11
   with:
     auth-host: custom-artifactory.com
     auth-username: ${{ secrets.PIXI_USERNAME }}
@@ -190,7 +190,7 @@ Specify the conda-token using the `auth-conda-token` input argument.
 This form of authentication (token is encoded in URL: `https://my-quetz-instance.com/t/<token>/get/custom-channel`) is used at [anaconda.org](https://anaconda.org) or with [quetz instances](https://github.com/mamba-org/quetz).
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.10
+- uses: prefix-dev/setup-pixi@v0.8.11
   with:
     auth-host: anaconda.org # or my-quetz-instance.com
     auth-conda-token: ${{ secrets.CONDA_TOKEN }}
@@ -202,7 +202,7 @@ Specify the S3 key pair using the `auth-access-key-id` and `auth-secret-access-k
 You can also specify the session token using the `auth-session-token` input argument.
 
 ```yaml
-- uses: prefix-dev/setup-pixi@v0.8.10
+- uses: prefix-dev/setup-pixi@v0.8.11
   with:
     auth-host: s3://my-s3-bucket
     auth-s3-access-key-id: ${{ secrets.ACCESS_KEY_ID }}
@@ -274,7 +274,7 @@ To this end, `setup-pixi` adds all environment variables set when executing `pix
 As a result, all installed binaries can be accessed without having to call `pixi run`.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.10
+- uses: prefix-dev/setup-pixi@v0.8.11
   with:
     activate-environment: true
 ```
@@ -282,7 +282,7 @@ As a result, all installed binaries can be accessed without having to call `pixi
 If you are installing multiple environments, you will need to specify the name of the environment that you want to be activated.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.10
+- uses: prefix-dev/setup-pixi@v0.8.11
   with:
     environments: >-
       py311
@@ -299,7 +299,7 @@ You can specify whether `setup-pixi` should run `pixi install --frozen` or `pixi
 See the [official documentation](https://prefix.dev/docs/pixi/cli#install) for more information about the `--frozen` and `--locked` flags.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.10
+- uses: prefix-dev/setup-pixi@v0.8.11
   with:
     locked: true
     # or
@@ -318,7 +318,7 @@ The first one is the debug logging of the action itself.
 This can be enabled by running the action with the `RUNNER_DEBUG` environment variable set to `true`.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.10
+- uses: prefix-dev/setup-pixi@v0.8.11
   env:
     RUNNER_DEBUG: true
 ```
@@ -336,7 +336,7 @@ The second type is the debug logging of the pixi executable.
 This can be specified by setting the `log-level` input.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.10
+- uses: prefix-dev/setup-pixi@v0.8.11
   with:
     # one of `q`, `default`, `v`, `vv`, or `vvv`.
     log-level: vvv
@@ -362,7 +362,7 @@ If nothing is specified, `post-cleanup` will default to `true`.
 On self-hosted runners, you also might want to alter the default pixi install location to a temporary location. You can use `pixi-bin-path: ${{ runner.temp }}/bin/pixi` to do this.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.10
+- uses: prefix-dev/setup-pixi@v0.8.11
   with:
     post-cleanup: true
     # ${{ runner.temp }}\Scripts\pixi.exe on Windows
@@ -378,7 +378,7 @@ You can also use a preinstalled local version of pixi on the runner by not setti
 This can be overwritten by setting the `manifest-path` input argument.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.10
+- uses: prefix-dev/setup-pixi@v0.8.11
   with:
     manifest-path: pyproject.toml
 ```
@@ -388,7 +388,7 @@ This can be overwritten by setting the `manifest-path` input argument.
 If you only want to install pixi and not install the current project, you can use the `run-install` option.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.10
+- uses: prefix-dev/setup-pixi@v0.8.11
   with:
     run-install: false
 ```
@@ -399,7 +399,7 @@ You can also download pixi from a custom URL by setting the `pixi-url` input arg
 Optionally, you can combine this with the `pixi-url-bearer-token` input argument to authenticate the download request.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.10
+- uses: prefix-dev/setup-pixi@v0.8.11
   with:
     pixi-url: https://pixi-mirror.example.com/releases/download/v0.48.0/pixi-x86_64-unknown-linux-musl
     pixi-url-bearer-token: ${{ secrets.PIXI_MIRROR_BEARER_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,8 @@ inputs:
     description: Version of pixi to install
   pixi-url:
     description: URL of pixi to install
+  pixi-url-bearer-token:
+    description: Bearer token to use for authentication when downloading pixi from a URL.
   log-level:
     description: |
       Log level for the pixi CLI.

--- a/dist/index.js
+++ b/dist/index.js
@@ -22425,9 +22425,9 @@ var require_balanced_match = __commonJS({
   }
 });
 
-// node_modules/.pnpm/brace-expansion@1.1.12/node_modules/brace-expansion/index.js
+// node_modules/.pnpm/brace-expansion@1.1.11/node_modules/brace-expansion/index.js
 var require_brace_expansion = __commonJS({
-  "node_modules/.pnpm/brace-expansion@1.1.12/node_modules/brace-expansion/index.js"(exports2, module2) {
+  "node_modules/.pnpm/brace-expansion@1.1.11/node_modules/brace-expansion/index.js"(exports2, module2) {
     "use strict";
     var concatMap = require_concat_map();
     var balanced = require_balanced_match();
@@ -22495,7 +22495,7 @@ var require_brace_expansion = __commonJS({
       var isSequence = isNumericSequence || isAlphaSequence;
       var isOptions = m.body.indexOf(",") >= 0;
       if (!isSequence && !isOptions) {
-        if (m.post.match(/,(?!,).*\}/)) {
+        if (m.post.match(/,.*\}/)) {
           str = m.pre + "{" + m.body + escClose + m.post;
           return expand(str);
         }
@@ -64246,7 +64246,7 @@ var import_process = require("process");
 var import_fs = require("fs");
 var core = __toESM(require_core());
 
-// node_modules/.pnpm/zod@3.25.67/node_modules/zod/dist/esm/v3/helpers/util.js
+// node_modules/.pnpm/zod@3.25.45/node_modules/zod/dist/esm/v3/helpers/util.js
 var util;
 (function(util4) {
   util4.assertEqual = (_) => {
@@ -64380,7 +64380,7 @@ var getParsedType = (data) => {
   }
 };
 
-// node_modules/.pnpm/zod@3.25.67/node_modules/zod/dist/esm/v3/ZodError.js
+// node_modules/.pnpm/zod@3.25.45/node_modules/zod/dist/esm/v3/ZodError.js
 var ZodIssueCode = util.arrayToEnum([
   "invalid_type",
   "invalid_literal",
@@ -64493,7 +64493,7 @@ ZodError.create = (issues) => {
   return error3;
 };
 
-// node_modules/.pnpm/zod@3.25.67/node_modules/zod/dist/esm/v3/locales/en.js
+// node_modules/.pnpm/zod@3.25.45/node_modules/zod/dist/esm/v3/locales/en.js
 var errorMap = (issue, _ctx) => {
   let message;
   switch (issue.code) {
@@ -64594,13 +64594,13 @@ var errorMap = (issue, _ctx) => {
 };
 var en_default = errorMap;
 
-// node_modules/.pnpm/zod@3.25.67/node_modules/zod/dist/esm/v3/errors.js
+// node_modules/.pnpm/zod@3.25.45/node_modules/zod/dist/esm/v3/errors.js
 var overrideErrorMap = en_default;
 function getErrorMap() {
   return overrideErrorMap;
 }
 
-// node_modules/.pnpm/zod@3.25.67/node_modules/zod/dist/esm/v3/helpers/parseUtil.js
+// node_modules/.pnpm/zod@3.25.45/node_modules/zod/dist/esm/v3/helpers/parseUtil.js
 var makeIssue = (params) => {
   const { data, path: path4, errorMaps, issueData } = params;
   const fullPath = [...path4, ...issueData.path || []];
@@ -64709,14 +64709,14 @@ var isDirty = (x) => x.status === "dirty";
 var isValid = (x) => x.status === "valid";
 var isAsync = (x) => typeof Promise !== "undefined" && x instanceof Promise;
 
-// node_modules/.pnpm/zod@3.25.67/node_modules/zod/dist/esm/v3/helpers/errorUtil.js
+// node_modules/.pnpm/zod@3.25.45/node_modules/zod/dist/esm/v3/helpers/errorUtil.js
 var errorUtil;
 (function(errorUtil2) {
   errorUtil2.errToObj = (message) => typeof message === "string" ? { message } : message || {};
   errorUtil2.toString = (message) => typeof message === "string" ? message : message?.message;
 })(errorUtil || (errorUtil = {}));
 
-// node_modules/.pnpm/zod@3.25.67/node_modules/zod/dist/esm/v3/types.js
+// node_modules/.pnpm/zod@3.25.45/node_modules/zod/dist/esm/v3/types.js
 var ParseInputLazyPath = class {
   constructor(parent, value, path4, key) {
     this._cachedPath = [];
@@ -68128,7 +68128,7 @@ function untildify(pathWithTilde) {
   return homeDirectory ? pathWithTilde.replace(/^~(?=$|\/|\\)/, homeDirectory) : pathWithTilde;
 }
 
-// node_modules/.pnpm/smol-toml@1.4.0/node_modules/smol-toml/dist/error.js
+// node_modules/.pnpm/smol-toml@1.3.4/node_modules/smol-toml/dist/error.js
 function getLineColFromPtr(string, ptr) {
   let lines = string.slice(0, ptr).split(/\r\n|\n|\r/g);
   return [lines.length, lines.pop().length + 1];
@@ -68168,7 +68168,7 @@ ${codeblock}`, options2);
   }
 };
 
-// node_modules/.pnpm/smol-toml@1.4.0/node_modules/smol-toml/dist/util.js
+// node_modules/.pnpm/smol-toml@1.3.4/node_modules/smol-toml/dist/util.js
 function indexOfNewline(str, start = 0, end = str.length) {
   let idx = str.indexOf("\n", start);
   if (str[idx - 1] === "\r")
@@ -68236,7 +68236,7 @@ function getStringEnd(str, seek) {
   return seek;
 }
 
-// node_modules/.pnpm/smol-toml@1.4.0/node_modules/smol-toml/dist/date.js
+// node_modules/.pnpm/smol-toml@1.3.4/node_modules/smol-toml/dist/date.js
 var DATE_TIME_RE = /^(\d{4}-\d{2}-\d{2})?[T ]?(?:(\d{2}):\d{2}:\d{2}(?:\.\d+)?)?(Z|[-+]\d{2}:\d{2})?$/i;
 var _hasDate, _hasTime, _offset;
 var _TomlDate = class _TomlDate extends Date {
@@ -68333,7 +68333,7 @@ _hasTime = new WeakMap();
 _offset = new WeakMap();
 var TomlDate = _TomlDate;
 
-// node_modules/.pnpm/smol-toml@1.4.0/node_modules/smol-toml/dist/primitive.js
+// node_modules/.pnpm/smol-toml@1.3.4/node_modules/smol-toml/dist/primitive.js
 var INT_REGEX = /^((0x[0-9a-fA-F](_?[0-9a-fA-F])*)|(([+-]|0[ob])?\d(_?\d)*))$/;
 var FLOAT_REGEX = /^[+-]?\d(_?\d)*(\.\d(_?\d)*)?([eE][+-]?\d(_?\d)*)?$/;
 var LEADING_ZERO = /^[+-]?0[0-9_]/;
@@ -68420,7 +68420,7 @@ function parseString(str, ptr = 0, endPtr = str.length) {
   }
   return parsed + str.slice(sliceStart, endPtr - 1);
 }
-function parseValue(value, toml, ptr, integersAsBigInt) {
+function parseValue(value, toml, ptr) {
   if (value === "true")
     return true;
   if (value === "false")
@@ -68432,36 +68432,31 @@ function parseValue(value, toml, ptr, integersAsBigInt) {
   if (value === "nan" || value === "+nan" || value === "-nan")
     return NaN;
   if (value === "-0")
-    return integersAsBigInt ? 0n : 0;
-  let isInt = INT_REGEX.test(value);
-  if (isInt || FLOAT_REGEX.test(value)) {
+    return 0;
+  let isInt;
+  if ((isInt = INT_REGEX.test(value)) || FLOAT_REGEX.test(value)) {
     if (LEADING_ZERO.test(value)) {
       throw new TomlError("leading zeroes are not allowed", {
         toml,
         ptr
       });
     }
-    value = value.replace(/_/g, "");
-    let numeric = +value;
+    let numeric = +value.replace(/_/g, "");
     if (isNaN(numeric)) {
       throw new TomlError("invalid number", {
         toml,
         ptr
       });
     }
-    if (isInt) {
-      if ((isInt = !Number.isSafeInteger(numeric)) && !integersAsBigInt) {
-        throw new TomlError("integer value cannot be represented losslessly", {
-          toml,
-          ptr
-        });
-      }
-      if (isInt || integersAsBigInt)
-        numeric = BigInt(value);
+    if (isInt && !Number.isSafeInteger(numeric)) {
+      throw new TomlError("integer value cannot be represented losslessly", {
+        toml,
+        ptr
+      });
     }
     return numeric;
   }
-  const date = new TomlDate(value);
+  let date = new TomlDate(value);
   if (!date.isValid()) {
     throw new TomlError("invalid value", {
       toml,
@@ -68471,7 +68466,7 @@ function parseValue(value, toml, ptr, integersAsBigInt) {
   return date;
 }
 
-// node_modules/.pnpm/smol-toml@1.4.0/node_modules/smol-toml/dist/extract.js
+// node_modules/.pnpm/smol-toml@1.3.4/node_modules/smol-toml/dist/extract.js
 function sliceAndTrimEndOf(str, startPtr, endPtr, allowNewLines) {
   let value = str.slice(startPtr, endPtr);
   let commentIdx = value.indexOf("#");
@@ -68491,7 +68486,7 @@ function sliceAndTrimEndOf(str, startPtr, endPtr, allowNewLines) {
   }
   return [trimmed, commentIdx];
 }
-function extractValue(str, ptr, end, depth, integersAsBigInt) {
+function extractValue(str, ptr, end, depth = -1) {
   if (depth === 0) {
     throw new TomlError("document contains excessively nested structures. aborting.", {
       toml: str,
@@ -68500,7 +68495,7 @@ function extractValue(str, ptr, end, depth, integersAsBigInt) {
   }
   let c = str[ptr];
   if (c === "[" || c === "{") {
-    let [value, endPtr2] = c === "[" ? parseArray(str, ptr, depth, integersAsBigInt) : parseInlineTable(str, ptr, depth, integersAsBigInt);
+    let [value, endPtr2] = c === "[" ? parseArray(str, ptr, depth) : parseInlineTable(str, ptr, depth);
     let newPtr = end ? skipUntil(str, endPtr2, ",", end) : endPtr2;
     if (endPtr2 - newPtr && end === "}") {
       let nextNewLine = indexOfNewline(str, endPtr2, newPtr);
@@ -68542,12 +68537,12 @@ function extractValue(str, ptr, end, depth, integersAsBigInt) {
     endPtr += +(str[endPtr] === ",");
   }
   return [
-    parseValue(slice[0], str, ptr, integersAsBigInt),
+    parseValue(slice[0], str, ptr),
     endPtr
   ];
 }
 
-// node_modules/.pnpm/smol-toml@1.4.0/node_modules/smol-toml/dist/struct.js
+// node_modules/.pnpm/smol-toml@1.3.4/node_modules/smol-toml/dist/struct.js
 var KEY_PART_RE = /^[a-zA-Z0-9-_]+[ \t]*$/;
 function parseKey(str, ptr, end = "=") {
   let dot = ptr - 1;
@@ -68616,20 +68611,28 @@ function parseKey(str, ptr, end = "=") {
   } while (dot + 1 && dot < endPtr);
   return [parsed, skipVoid(str, endPtr + 1, true, true)];
 }
-function parseInlineTable(str, ptr, depth, integersAsBigInt) {
+function parseInlineTable(str, ptr, depth = -1) {
   let res = {};
   let seen = /* @__PURE__ */ new Set();
   let c;
   let comma = 0;
   ptr++;
   while ((c = str[ptr++]) !== "}" && c) {
-    let err = { toml: str, ptr: ptr - 1 };
     if (c === "\n") {
-      throw new TomlError("newlines are not allowed in inline tables", err);
+      throw new TomlError("newlines are not allowed in inline tables", {
+        toml: str,
+        ptr: ptr - 1
+      });
     } else if (c === "#") {
-      throw new TomlError("inline tables cannot contain comments", err);
+      throw new TomlError("inline tables cannot contain comments", {
+        toml: str,
+        ptr: ptr - 1
+      });
     } else if (c === ",") {
-      throw new TomlError("expected key-value, found comma", err);
+      throw new TomlError("expected key-value, found comma", {
+        toml: str,
+        ptr: ptr - 1
+      });
     } else if (c !== " " && c !== "	") {
       let k;
       let t = res;
@@ -68655,7 +68658,7 @@ function parseInlineTable(str, ptr, depth, integersAsBigInt) {
           ptr
         });
       }
-      let [value, valueEndPtr] = extractValue(str, keyEndPtr, "}", depth - 1, integersAsBigInt);
+      let [value, valueEndPtr] = extractValue(str, keyEndPtr, "}", depth - 1);
       seen.add(value);
       t[k] = value;
       ptr = valueEndPtr;
@@ -68676,7 +68679,7 @@ function parseInlineTable(str, ptr, depth, integersAsBigInt) {
   }
   return [res, ptr];
 }
-function parseArray(str, ptr, depth, integersAsBigInt) {
+function parseArray(str, ptr, depth = -1) {
   let res = [];
   let c;
   ptr++;
@@ -68689,7 +68692,7 @@ function parseArray(str, ptr, depth, integersAsBigInt) {
     } else if (c === "#")
       ptr = skipComment(str, ptr);
     else if (c !== " " && c !== "	" && c !== "\n" && c !== "\r") {
-      let e = extractValue(str, ptr - 1, "]", depth - 1, integersAsBigInt);
+      let e = extractValue(str, ptr - 1, "]", depth - 1);
       res.push(e[0]);
       ptr = e[1];
     }
@@ -68703,7 +68706,7 @@ function parseArray(str, ptr, depth, integersAsBigInt) {
   return [res, ptr];
 }
 
-// node_modules/.pnpm/smol-toml@1.4.0/node_modules/smol-toml/dist/parse.js
+// node_modules/.pnpm/smol-toml@1.3.4/node_modules/smol-toml/dist/parse.js
 function peekTable(key, table, meta, type2) {
   let t = table;
   let m = meta;
@@ -68763,7 +68766,8 @@ function peekTable(key, table, meta, type2) {
   }
   return [k, t, state3.c];
 }
-function parse(toml, { maxDepth = 1e3, integersAsBigInt } = {}) {
+function parse(toml, opts) {
+  let maxDepth = opts?.maxDepth ?? 1e3;
   let res = {};
   let meta = {};
   let tbl = res;
@@ -68812,7 +68816,7 @@ function parse(toml, { maxDepth = 1e3, integersAsBigInt } = {}) {
           ptr
         });
       }
-      let v = extractValue(toml, k[1], void 0, maxDepth, integersAsBigInt);
+      let v = extractValue(toml, k[1], void 0, maxDepth);
       p[1][p[0]] = v[0];
       ptr = v[1];
     }
@@ -68867,6 +68871,9 @@ var parseOrUndefinedList = (key, schema) => {
 var validateInputs = (inputs) => {
   if (inputs.pixiVersion && inputs.pixiUrl) {
     throw new Error("You need to specify either pixi-version or pixi-url");
+  }
+  if (inputs.pixiUrlBearerToken && !inputs.pixiUrl) {
+    throw new Error("You need to specify pixi-url when using pixi-url-bearer-token");
   }
   if (inputs.cacheKey !== void 0 && inputs.cache === false) {
     throw new Error("Cannot specify cache key without caching");
@@ -68946,7 +68953,7 @@ var determinePixiInstallation = (pixiUrlOrVersionSet, pixiBinPath) => {
 };
 var inferOptions = (inputs) => {
   const runInstall = inputs.runInstall ?? true;
-  const pixiSource = inputs.pixiVersion ? { version: inputs.pixiVersion } : inputs.pixiUrl ? { url: inputs.pixiUrl } : { version: "latest" };
+  const pixiSource = inputs.pixiVersion ? { version: inputs.pixiVersion } : inputs.pixiUrl ? { url: inputs.pixiUrl, bearerToken: inputs.pixiUrlBearerToken } : { version: "latest" };
   const { downloadPixi: downloadPixi2, pixiBinPath } = determinePixiInstallation(
     !!inputs.pixiVersion || !!inputs.pixiUrl,
     inputs.pixiBinPath
@@ -69037,6 +69044,7 @@ var getOptions = () => {
       "pixi-version must either be `latest` or a version string matching `vX.Y.Z`."
     ),
     pixiUrl: parseOrUndefined("pixi-url", stringType().url()),
+    pixiUrlBearerToken: parseOrUndefined("pixi-url-bearer-token", stringType()),
     logLevel: parseOrUndefined(
       "log-level",
       logLevelSchema,
@@ -69302,10 +69310,12 @@ var activateEnvironment = async (environment) => {
 // src/main.ts
 var downloadPixi = (source) => {
   const url2 = "version" in source ? getPixiUrlFromVersion(source.version) : source.url;
+  const auth = "bearerToken" in source && source.bearerToken ? `Bearer ${source.bearerToken}` : "";
   return core5.group("Downloading Pixi", () => {
     core5.debug("Installing pixi");
     core5.debug(`Downloading pixi from ${url2}`);
-    return import_promises2.default.mkdir(import_path3.default.dirname(options.pixiBinPath), { recursive: true }).then(() => (0, import_tool_cache.downloadTool)(url2, options.pixiBinPath)).then((_downloadPath) => import_promises2.default.chmod(options.pixiBinPath, 493)).then(() => {
+    core5.debug(`Using Bearer auth: ${auth ? "yes" : "no"}`);
+    return import_promises2.default.mkdir(import_path3.default.dirname(options.pixiBinPath), { recursive: true }).then(() => (0, import_tool_cache.downloadTool)(url2, options.pixiBinPath, auth)).then((_downloadPath) => import_promises2.default.chmod(options.pixiBinPath, 493)).then(() => {
       core5.info(`Pixi installed to ${options.pixiBinPath}`);
     });
   });

--- a/dist/index.js
+++ b/dist/index.js
@@ -22425,9 +22425,9 @@ var require_balanced_match = __commonJS({
   }
 });
 
-// node_modules/.pnpm/brace-expansion@1.1.11/node_modules/brace-expansion/index.js
+// node_modules/.pnpm/brace-expansion@1.1.12/node_modules/brace-expansion/index.js
 var require_brace_expansion = __commonJS({
-  "node_modules/.pnpm/brace-expansion@1.1.11/node_modules/brace-expansion/index.js"(exports2, module2) {
+  "node_modules/.pnpm/brace-expansion@1.1.12/node_modules/brace-expansion/index.js"(exports2, module2) {
     "use strict";
     var concatMap = require_concat_map();
     var balanced = require_balanced_match();
@@ -22495,7 +22495,7 @@ var require_brace_expansion = __commonJS({
       var isSequence = isNumericSequence || isAlphaSequence;
       var isOptions = m.body.indexOf(",") >= 0;
       if (!isSequence && !isOptions) {
-        if (m.post.match(/,.*\}/)) {
+        if (m.post.match(/,(?!,).*\}/)) {
           str = m.pre + "{" + m.body + escClose + m.post;
           return expand(str);
         }
@@ -64246,7 +64246,7 @@ var import_process = require("process");
 var import_fs = require("fs");
 var core = __toESM(require_core());
 
-// node_modules/.pnpm/zod@3.25.45/node_modules/zod/dist/esm/v3/helpers/util.js
+// node_modules/.pnpm/zod@3.25.67/node_modules/zod/dist/esm/v3/helpers/util.js
 var util;
 (function(util4) {
   util4.assertEqual = (_) => {
@@ -64380,7 +64380,7 @@ var getParsedType = (data) => {
   }
 };
 
-// node_modules/.pnpm/zod@3.25.45/node_modules/zod/dist/esm/v3/ZodError.js
+// node_modules/.pnpm/zod@3.25.67/node_modules/zod/dist/esm/v3/ZodError.js
 var ZodIssueCode = util.arrayToEnum([
   "invalid_type",
   "invalid_literal",
@@ -64493,7 +64493,7 @@ ZodError.create = (issues) => {
   return error3;
 };
 
-// node_modules/.pnpm/zod@3.25.45/node_modules/zod/dist/esm/v3/locales/en.js
+// node_modules/.pnpm/zod@3.25.67/node_modules/zod/dist/esm/v3/locales/en.js
 var errorMap = (issue, _ctx) => {
   let message;
   switch (issue.code) {
@@ -64594,13 +64594,13 @@ var errorMap = (issue, _ctx) => {
 };
 var en_default = errorMap;
 
-// node_modules/.pnpm/zod@3.25.45/node_modules/zod/dist/esm/v3/errors.js
+// node_modules/.pnpm/zod@3.25.67/node_modules/zod/dist/esm/v3/errors.js
 var overrideErrorMap = en_default;
 function getErrorMap() {
   return overrideErrorMap;
 }
 
-// node_modules/.pnpm/zod@3.25.45/node_modules/zod/dist/esm/v3/helpers/parseUtil.js
+// node_modules/.pnpm/zod@3.25.67/node_modules/zod/dist/esm/v3/helpers/parseUtil.js
 var makeIssue = (params) => {
   const { data, path: path4, errorMaps, issueData } = params;
   const fullPath = [...path4, ...issueData.path || []];
@@ -64709,14 +64709,14 @@ var isDirty = (x) => x.status === "dirty";
 var isValid = (x) => x.status === "valid";
 var isAsync = (x) => typeof Promise !== "undefined" && x instanceof Promise;
 
-// node_modules/.pnpm/zod@3.25.45/node_modules/zod/dist/esm/v3/helpers/errorUtil.js
+// node_modules/.pnpm/zod@3.25.67/node_modules/zod/dist/esm/v3/helpers/errorUtil.js
 var errorUtil;
 (function(errorUtil2) {
   errorUtil2.errToObj = (message) => typeof message === "string" ? { message } : message || {};
   errorUtil2.toString = (message) => typeof message === "string" ? message : message?.message;
 })(errorUtil || (errorUtil = {}));
 
-// node_modules/.pnpm/zod@3.25.45/node_modules/zod/dist/esm/v3/types.js
+// node_modules/.pnpm/zod@3.25.67/node_modules/zod/dist/esm/v3/types.js
 var ParseInputLazyPath = class {
   constructor(parent, value, path4, key) {
     this._cachedPath = [];
@@ -68128,7 +68128,7 @@ function untildify(pathWithTilde) {
   return homeDirectory ? pathWithTilde.replace(/^~(?=$|\/|\\)/, homeDirectory) : pathWithTilde;
 }
 
-// node_modules/.pnpm/smol-toml@1.3.4/node_modules/smol-toml/dist/error.js
+// node_modules/.pnpm/smol-toml@1.4.0/node_modules/smol-toml/dist/error.js
 function getLineColFromPtr(string, ptr) {
   let lines = string.slice(0, ptr).split(/\r\n|\n|\r/g);
   return [lines.length, lines.pop().length + 1];
@@ -68168,7 +68168,7 @@ ${codeblock}`, options2);
   }
 };
 
-// node_modules/.pnpm/smol-toml@1.3.4/node_modules/smol-toml/dist/util.js
+// node_modules/.pnpm/smol-toml@1.4.0/node_modules/smol-toml/dist/util.js
 function indexOfNewline(str, start = 0, end = str.length) {
   let idx = str.indexOf("\n", start);
   if (str[idx - 1] === "\r")
@@ -68236,7 +68236,7 @@ function getStringEnd(str, seek) {
   return seek;
 }
 
-// node_modules/.pnpm/smol-toml@1.3.4/node_modules/smol-toml/dist/date.js
+// node_modules/.pnpm/smol-toml@1.4.0/node_modules/smol-toml/dist/date.js
 var DATE_TIME_RE = /^(\d{4}-\d{2}-\d{2})?[T ]?(?:(\d{2}):\d{2}:\d{2}(?:\.\d+)?)?(Z|[-+]\d{2}:\d{2})?$/i;
 var _hasDate, _hasTime, _offset;
 var _TomlDate = class _TomlDate extends Date {
@@ -68333,7 +68333,7 @@ _hasTime = new WeakMap();
 _offset = new WeakMap();
 var TomlDate = _TomlDate;
 
-// node_modules/.pnpm/smol-toml@1.3.4/node_modules/smol-toml/dist/primitive.js
+// node_modules/.pnpm/smol-toml@1.4.0/node_modules/smol-toml/dist/primitive.js
 var INT_REGEX = /^((0x[0-9a-fA-F](_?[0-9a-fA-F])*)|(([+-]|0[ob])?\d(_?\d)*))$/;
 var FLOAT_REGEX = /^[+-]?\d(_?\d)*(\.\d(_?\d)*)?([eE][+-]?\d(_?\d)*)?$/;
 var LEADING_ZERO = /^[+-]?0[0-9_]/;
@@ -68420,7 +68420,7 @@ function parseString(str, ptr = 0, endPtr = str.length) {
   }
   return parsed + str.slice(sliceStart, endPtr - 1);
 }
-function parseValue(value, toml, ptr) {
+function parseValue(value, toml, ptr, integersAsBigInt) {
   if (value === "true")
     return true;
   if (value === "false")
@@ -68432,31 +68432,36 @@ function parseValue(value, toml, ptr) {
   if (value === "nan" || value === "+nan" || value === "-nan")
     return NaN;
   if (value === "-0")
-    return 0;
-  let isInt;
-  if ((isInt = INT_REGEX.test(value)) || FLOAT_REGEX.test(value)) {
+    return integersAsBigInt ? 0n : 0;
+  let isInt = INT_REGEX.test(value);
+  if (isInt || FLOAT_REGEX.test(value)) {
     if (LEADING_ZERO.test(value)) {
       throw new TomlError("leading zeroes are not allowed", {
         toml,
         ptr
       });
     }
-    let numeric = +value.replace(/_/g, "");
+    value = value.replace(/_/g, "");
+    let numeric = +value;
     if (isNaN(numeric)) {
       throw new TomlError("invalid number", {
         toml,
         ptr
       });
     }
-    if (isInt && !Number.isSafeInteger(numeric)) {
-      throw new TomlError("integer value cannot be represented losslessly", {
-        toml,
-        ptr
-      });
+    if (isInt) {
+      if ((isInt = !Number.isSafeInteger(numeric)) && !integersAsBigInt) {
+        throw new TomlError("integer value cannot be represented losslessly", {
+          toml,
+          ptr
+        });
+      }
+      if (isInt || integersAsBigInt)
+        numeric = BigInt(value);
     }
     return numeric;
   }
-  let date = new TomlDate(value);
+  const date = new TomlDate(value);
   if (!date.isValid()) {
     throw new TomlError("invalid value", {
       toml,
@@ -68466,7 +68471,7 @@ function parseValue(value, toml, ptr) {
   return date;
 }
 
-// node_modules/.pnpm/smol-toml@1.3.4/node_modules/smol-toml/dist/extract.js
+// node_modules/.pnpm/smol-toml@1.4.0/node_modules/smol-toml/dist/extract.js
 function sliceAndTrimEndOf(str, startPtr, endPtr, allowNewLines) {
   let value = str.slice(startPtr, endPtr);
   let commentIdx = value.indexOf("#");
@@ -68486,7 +68491,7 @@ function sliceAndTrimEndOf(str, startPtr, endPtr, allowNewLines) {
   }
   return [trimmed, commentIdx];
 }
-function extractValue(str, ptr, end, depth = -1) {
+function extractValue(str, ptr, end, depth, integersAsBigInt) {
   if (depth === 0) {
     throw new TomlError("document contains excessively nested structures. aborting.", {
       toml: str,
@@ -68495,7 +68500,7 @@ function extractValue(str, ptr, end, depth = -1) {
   }
   let c = str[ptr];
   if (c === "[" || c === "{") {
-    let [value, endPtr2] = c === "[" ? parseArray(str, ptr, depth) : parseInlineTable(str, ptr, depth);
+    let [value, endPtr2] = c === "[" ? parseArray(str, ptr, depth, integersAsBigInt) : parseInlineTable(str, ptr, depth, integersAsBigInt);
     let newPtr = end ? skipUntil(str, endPtr2, ",", end) : endPtr2;
     if (endPtr2 - newPtr && end === "}") {
       let nextNewLine = indexOfNewline(str, endPtr2, newPtr);
@@ -68537,12 +68542,12 @@ function extractValue(str, ptr, end, depth = -1) {
     endPtr += +(str[endPtr] === ",");
   }
   return [
-    parseValue(slice[0], str, ptr),
+    parseValue(slice[0], str, ptr, integersAsBigInt),
     endPtr
   ];
 }
 
-// node_modules/.pnpm/smol-toml@1.3.4/node_modules/smol-toml/dist/struct.js
+// node_modules/.pnpm/smol-toml@1.4.0/node_modules/smol-toml/dist/struct.js
 var KEY_PART_RE = /^[a-zA-Z0-9-_]+[ \t]*$/;
 function parseKey(str, ptr, end = "=") {
   let dot = ptr - 1;
@@ -68611,28 +68616,20 @@ function parseKey(str, ptr, end = "=") {
   } while (dot + 1 && dot < endPtr);
   return [parsed, skipVoid(str, endPtr + 1, true, true)];
 }
-function parseInlineTable(str, ptr, depth = -1) {
+function parseInlineTable(str, ptr, depth, integersAsBigInt) {
   let res = {};
   let seen = /* @__PURE__ */ new Set();
   let c;
   let comma = 0;
   ptr++;
   while ((c = str[ptr++]) !== "}" && c) {
+    let err = { toml: str, ptr: ptr - 1 };
     if (c === "\n") {
-      throw new TomlError("newlines are not allowed in inline tables", {
-        toml: str,
-        ptr: ptr - 1
-      });
+      throw new TomlError("newlines are not allowed in inline tables", err);
     } else if (c === "#") {
-      throw new TomlError("inline tables cannot contain comments", {
-        toml: str,
-        ptr: ptr - 1
-      });
+      throw new TomlError("inline tables cannot contain comments", err);
     } else if (c === ",") {
-      throw new TomlError("expected key-value, found comma", {
-        toml: str,
-        ptr: ptr - 1
-      });
+      throw new TomlError("expected key-value, found comma", err);
     } else if (c !== " " && c !== "	") {
       let k;
       let t = res;
@@ -68658,7 +68655,7 @@ function parseInlineTable(str, ptr, depth = -1) {
           ptr
         });
       }
-      let [value, valueEndPtr] = extractValue(str, keyEndPtr, "}", depth - 1);
+      let [value, valueEndPtr] = extractValue(str, keyEndPtr, "}", depth - 1, integersAsBigInt);
       seen.add(value);
       t[k] = value;
       ptr = valueEndPtr;
@@ -68679,7 +68676,7 @@ function parseInlineTable(str, ptr, depth = -1) {
   }
   return [res, ptr];
 }
-function parseArray(str, ptr, depth = -1) {
+function parseArray(str, ptr, depth, integersAsBigInt) {
   let res = [];
   let c;
   ptr++;
@@ -68692,7 +68689,7 @@ function parseArray(str, ptr, depth = -1) {
     } else if (c === "#")
       ptr = skipComment(str, ptr);
     else if (c !== " " && c !== "	" && c !== "\n" && c !== "\r") {
-      let e = extractValue(str, ptr - 1, "]", depth - 1);
+      let e = extractValue(str, ptr - 1, "]", depth - 1, integersAsBigInt);
       res.push(e[0]);
       ptr = e[1];
     }
@@ -68706,7 +68703,7 @@ function parseArray(str, ptr, depth = -1) {
   return [res, ptr];
 }
 
-// node_modules/.pnpm/smol-toml@1.3.4/node_modules/smol-toml/dist/parse.js
+// node_modules/.pnpm/smol-toml@1.4.0/node_modules/smol-toml/dist/parse.js
 function peekTable(key, table, meta, type2) {
   let t = table;
   let m = meta;
@@ -68766,8 +68763,7 @@ function peekTable(key, table, meta, type2) {
   }
   return [k, t, state3.c];
 }
-function parse(toml, opts) {
-  let maxDepth = opts?.maxDepth ?? 1e3;
+function parse(toml, { maxDepth = 1e3, integersAsBigInt } = {}) {
   let res = {};
   let meta = {};
   let tbl = res;
@@ -68816,7 +68812,7 @@ function parse(toml, opts) {
           ptr
         });
       }
-      let v = extractValue(toml, k[1], void 0, maxDepth);
+      let v = extractValue(toml, k[1], void 0, maxDepth, integersAsBigInt);
       p[1][p[0]] = v[0];
       ptr = v[1];
     }

--- a/dist/post.js
+++ b/dist/post.js
@@ -20122,7 +20122,7 @@ var import_process = require("process");
 var import_fs = require("fs");
 var core = __toESM(require_core());
 
-// node_modules/.pnpm/zod@3.25.45/node_modules/zod/dist/esm/v3/helpers/util.js
+// node_modules/.pnpm/zod@3.25.67/node_modules/zod/dist/esm/v3/helpers/util.js
 var util;
 (function(util2) {
   util2.assertEqual = (_) => {
@@ -20256,7 +20256,7 @@ var getParsedType = (data) => {
   }
 };
 
-// node_modules/.pnpm/zod@3.25.45/node_modules/zod/dist/esm/v3/ZodError.js
+// node_modules/.pnpm/zod@3.25.67/node_modules/zod/dist/esm/v3/ZodError.js
 var ZodIssueCode = util.arrayToEnum([
   "invalid_type",
   "invalid_literal",
@@ -20369,7 +20369,7 @@ ZodError.create = (issues) => {
   return error2;
 };
 
-// node_modules/.pnpm/zod@3.25.45/node_modules/zod/dist/esm/v3/locales/en.js
+// node_modules/.pnpm/zod@3.25.67/node_modules/zod/dist/esm/v3/locales/en.js
 var errorMap = (issue, _ctx) => {
   let message;
   switch (issue.code) {
@@ -20470,13 +20470,13 @@ var errorMap = (issue, _ctx) => {
 };
 var en_default = errorMap;
 
-// node_modules/.pnpm/zod@3.25.45/node_modules/zod/dist/esm/v3/errors.js
+// node_modules/.pnpm/zod@3.25.67/node_modules/zod/dist/esm/v3/errors.js
 var overrideErrorMap = en_default;
 function getErrorMap() {
   return overrideErrorMap;
 }
 
-// node_modules/.pnpm/zod@3.25.45/node_modules/zod/dist/esm/v3/helpers/parseUtil.js
+// node_modules/.pnpm/zod@3.25.67/node_modules/zod/dist/esm/v3/helpers/parseUtil.js
 var makeIssue = (params) => {
   const { data, path: path3, errorMaps, issueData } = params;
   const fullPath = [...path3, ...issueData.path || []];
@@ -20585,14 +20585,14 @@ var isDirty = (x) => x.status === "dirty";
 var isValid = (x) => x.status === "valid";
 var isAsync = (x) => typeof Promise !== "undefined" && x instanceof Promise;
 
-// node_modules/.pnpm/zod@3.25.45/node_modules/zod/dist/esm/v3/helpers/errorUtil.js
+// node_modules/.pnpm/zod@3.25.67/node_modules/zod/dist/esm/v3/helpers/errorUtil.js
 var errorUtil;
 (function(errorUtil2) {
   errorUtil2.errToObj = (message) => typeof message === "string" ? { message } : message || {};
   errorUtil2.toString = (message) => typeof message === "string" ? message : message?.message;
 })(errorUtil || (errorUtil = {}));
 
-// node_modules/.pnpm/zod@3.25.45/node_modules/zod/dist/esm/v3/types.js
+// node_modules/.pnpm/zod@3.25.67/node_modules/zod/dist/esm/v3/types.js
 var ParseInputLazyPath = class {
   constructor(parent, value, path3, key) {
     this._cachedPath = [];
@@ -24004,7 +24004,7 @@ function untildify(pathWithTilde) {
   return homeDirectory ? pathWithTilde.replace(/^~(?=$|\/|\\)/, homeDirectory) : pathWithTilde;
 }
 
-// node_modules/.pnpm/smol-toml@1.3.4/node_modules/smol-toml/dist/error.js
+// node_modules/.pnpm/smol-toml@1.4.0/node_modules/smol-toml/dist/error.js
 function getLineColFromPtr(string, ptr) {
   let lines = string.slice(0, ptr).split(/\r\n|\n|\r/g);
   return [lines.length, lines.pop().length + 1];
@@ -24044,7 +24044,7 @@ ${codeblock}`, options2);
   }
 };
 
-// node_modules/.pnpm/smol-toml@1.3.4/node_modules/smol-toml/dist/util.js
+// node_modules/.pnpm/smol-toml@1.4.0/node_modules/smol-toml/dist/util.js
 function indexOfNewline(str, start = 0, end = str.length) {
   let idx = str.indexOf("\n", start);
   if (str[idx - 1] === "\r")
@@ -24112,7 +24112,7 @@ function getStringEnd(str, seek) {
   return seek;
 }
 
-// node_modules/.pnpm/smol-toml@1.3.4/node_modules/smol-toml/dist/date.js
+// node_modules/.pnpm/smol-toml@1.4.0/node_modules/smol-toml/dist/date.js
 var DATE_TIME_RE = /^(\d{4}-\d{2}-\d{2})?[T ]?(?:(\d{2}):\d{2}:\d{2}(?:\.\d+)?)?(Z|[-+]\d{2}:\d{2})?$/i;
 var _hasDate, _hasTime, _offset;
 var _TomlDate = class _TomlDate extends Date {
@@ -24209,7 +24209,7 @@ _hasTime = new WeakMap();
 _offset = new WeakMap();
 var TomlDate = _TomlDate;
 
-// node_modules/.pnpm/smol-toml@1.3.4/node_modules/smol-toml/dist/primitive.js
+// node_modules/.pnpm/smol-toml@1.4.0/node_modules/smol-toml/dist/primitive.js
 var INT_REGEX = /^((0x[0-9a-fA-F](_?[0-9a-fA-F])*)|(([+-]|0[ob])?\d(_?\d)*))$/;
 var FLOAT_REGEX = /^[+-]?\d(_?\d)*(\.\d(_?\d)*)?([eE][+-]?\d(_?\d)*)?$/;
 var LEADING_ZERO = /^[+-]?0[0-9_]/;
@@ -24296,7 +24296,7 @@ function parseString(str, ptr = 0, endPtr = str.length) {
   }
   return parsed + str.slice(sliceStart, endPtr - 1);
 }
-function parseValue(value, toml, ptr) {
+function parseValue(value, toml, ptr, integersAsBigInt) {
   if (value === "true")
     return true;
   if (value === "false")
@@ -24308,31 +24308,36 @@ function parseValue(value, toml, ptr) {
   if (value === "nan" || value === "+nan" || value === "-nan")
     return NaN;
   if (value === "-0")
-    return 0;
-  let isInt;
-  if ((isInt = INT_REGEX.test(value)) || FLOAT_REGEX.test(value)) {
+    return integersAsBigInt ? 0n : 0;
+  let isInt = INT_REGEX.test(value);
+  if (isInt || FLOAT_REGEX.test(value)) {
     if (LEADING_ZERO.test(value)) {
       throw new TomlError("leading zeroes are not allowed", {
         toml,
         ptr
       });
     }
-    let numeric = +value.replace(/_/g, "");
+    value = value.replace(/_/g, "");
+    let numeric = +value;
     if (isNaN(numeric)) {
       throw new TomlError("invalid number", {
         toml,
         ptr
       });
     }
-    if (isInt && !Number.isSafeInteger(numeric)) {
-      throw new TomlError("integer value cannot be represented losslessly", {
-        toml,
-        ptr
-      });
+    if (isInt) {
+      if ((isInt = !Number.isSafeInteger(numeric)) && !integersAsBigInt) {
+        throw new TomlError("integer value cannot be represented losslessly", {
+          toml,
+          ptr
+        });
+      }
+      if (isInt || integersAsBigInt)
+        numeric = BigInt(value);
     }
     return numeric;
   }
-  let date = new TomlDate(value);
+  const date = new TomlDate(value);
   if (!date.isValid()) {
     throw new TomlError("invalid value", {
       toml,
@@ -24342,7 +24347,7 @@ function parseValue(value, toml, ptr) {
   return date;
 }
 
-// node_modules/.pnpm/smol-toml@1.3.4/node_modules/smol-toml/dist/extract.js
+// node_modules/.pnpm/smol-toml@1.4.0/node_modules/smol-toml/dist/extract.js
 function sliceAndTrimEndOf(str, startPtr, endPtr, allowNewLines) {
   let value = str.slice(startPtr, endPtr);
   let commentIdx = value.indexOf("#");
@@ -24362,7 +24367,7 @@ function sliceAndTrimEndOf(str, startPtr, endPtr, allowNewLines) {
   }
   return [trimmed, commentIdx];
 }
-function extractValue(str, ptr, end, depth = -1) {
+function extractValue(str, ptr, end, depth, integersAsBigInt) {
   if (depth === 0) {
     throw new TomlError("document contains excessively nested structures. aborting.", {
       toml: str,
@@ -24371,7 +24376,7 @@ function extractValue(str, ptr, end, depth = -1) {
   }
   let c = str[ptr];
   if (c === "[" || c === "{") {
-    let [value, endPtr2] = c === "[" ? parseArray(str, ptr, depth) : parseInlineTable(str, ptr, depth);
+    let [value, endPtr2] = c === "[" ? parseArray(str, ptr, depth, integersAsBigInt) : parseInlineTable(str, ptr, depth, integersAsBigInt);
     let newPtr = end ? skipUntil(str, endPtr2, ",", end) : endPtr2;
     if (endPtr2 - newPtr && end === "}") {
       let nextNewLine = indexOfNewline(str, endPtr2, newPtr);
@@ -24413,12 +24418,12 @@ function extractValue(str, ptr, end, depth = -1) {
     endPtr += +(str[endPtr] === ",");
   }
   return [
-    parseValue(slice[0], str, ptr),
+    parseValue(slice[0], str, ptr, integersAsBigInt),
     endPtr
   ];
 }
 
-// node_modules/.pnpm/smol-toml@1.3.4/node_modules/smol-toml/dist/struct.js
+// node_modules/.pnpm/smol-toml@1.4.0/node_modules/smol-toml/dist/struct.js
 var KEY_PART_RE = /^[a-zA-Z0-9-_]+[ \t]*$/;
 function parseKey(str, ptr, end = "=") {
   let dot = ptr - 1;
@@ -24487,28 +24492,20 @@ function parseKey(str, ptr, end = "=") {
   } while (dot + 1 && dot < endPtr);
   return [parsed, skipVoid(str, endPtr + 1, true, true)];
 }
-function parseInlineTable(str, ptr, depth = -1) {
+function parseInlineTable(str, ptr, depth, integersAsBigInt) {
   let res = {};
   let seen = /* @__PURE__ */ new Set();
   let c;
   let comma = 0;
   ptr++;
   while ((c = str[ptr++]) !== "}" && c) {
+    let err = { toml: str, ptr: ptr - 1 };
     if (c === "\n") {
-      throw new TomlError("newlines are not allowed in inline tables", {
-        toml: str,
-        ptr: ptr - 1
-      });
+      throw new TomlError("newlines are not allowed in inline tables", err);
     } else if (c === "#") {
-      throw new TomlError("inline tables cannot contain comments", {
-        toml: str,
-        ptr: ptr - 1
-      });
+      throw new TomlError("inline tables cannot contain comments", err);
     } else if (c === ",") {
-      throw new TomlError("expected key-value, found comma", {
-        toml: str,
-        ptr: ptr - 1
-      });
+      throw new TomlError("expected key-value, found comma", err);
     } else if (c !== " " && c !== "	") {
       let k;
       let t = res;
@@ -24534,7 +24531,7 @@ function parseInlineTable(str, ptr, depth = -1) {
           ptr
         });
       }
-      let [value, valueEndPtr] = extractValue(str, keyEndPtr, "}", depth - 1);
+      let [value, valueEndPtr] = extractValue(str, keyEndPtr, "}", depth - 1, integersAsBigInt);
       seen.add(value);
       t[k] = value;
       ptr = valueEndPtr;
@@ -24555,7 +24552,7 @@ function parseInlineTable(str, ptr, depth = -1) {
   }
   return [res, ptr];
 }
-function parseArray(str, ptr, depth = -1) {
+function parseArray(str, ptr, depth, integersAsBigInt) {
   let res = [];
   let c;
   ptr++;
@@ -24568,7 +24565,7 @@ function parseArray(str, ptr, depth = -1) {
     } else if (c === "#")
       ptr = skipComment(str, ptr);
     else if (c !== " " && c !== "	" && c !== "\n" && c !== "\r") {
-      let e = extractValue(str, ptr - 1, "]", depth - 1);
+      let e = extractValue(str, ptr - 1, "]", depth - 1, integersAsBigInt);
       res.push(e[0]);
       ptr = e[1];
     }
@@ -24582,7 +24579,7 @@ function parseArray(str, ptr, depth = -1) {
   return [res, ptr];
 }
 
-// node_modules/.pnpm/smol-toml@1.3.4/node_modules/smol-toml/dist/parse.js
+// node_modules/.pnpm/smol-toml@1.4.0/node_modules/smol-toml/dist/parse.js
 function peekTable(key, table, meta, type) {
   let t = table;
   let m = meta;
@@ -24642,8 +24639,7 @@ function peekTable(key, table, meta, type) {
   }
   return [k, t, state.c];
 }
-function parse(toml, opts) {
-  let maxDepth = opts?.maxDepth ?? 1e3;
+function parse(toml, { maxDepth = 1e3, integersAsBigInt } = {}) {
   let res = {};
   let meta = {};
   let tbl = res;
@@ -24692,7 +24688,7 @@ function parse(toml, opts) {
           ptr
         });
       }
-      let v = extractValue(toml, k[1], void 0, maxDepth);
+      let v = extractValue(toml, k[1], void 0, maxDepth, integersAsBigInt);
       p[1][p[0]] = v[0];
       ptr = v[1];
     }

--- a/dist/post.js
+++ b/dist/post.js
@@ -20122,7 +20122,7 @@ var import_process = require("process");
 var import_fs = require("fs");
 var core = __toESM(require_core());
 
-// node_modules/.pnpm/zod@3.25.67/node_modules/zod/dist/esm/v3/helpers/util.js
+// node_modules/.pnpm/zod@3.25.45/node_modules/zod/dist/esm/v3/helpers/util.js
 var util;
 (function(util2) {
   util2.assertEqual = (_) => {
@@ -20256,7 +20256,7 @@ var getParsedType = (data) => {
   }
 };
 
-// node_modules/.pnpm/zod@3.25.67/node_modules/zod/dist/esm/v3/ZodError.js
+// node_modules/.pnpm/zod@3.25.45/node_modules/zod/dist/esm/v3/ZodError.js
 var ZodIssueCode = util.arrayToEnum([
   "invalid_type",
   "invalid_literal",
@@ -20369,7 +20369,7 @@ ZodError.create = (issues) => {
   return error2;
 };
 
-// node_modules/.pnpm/zod@3.25.67/node_modules/zod/dist/esm/v3/locales/en.js
+// node_modules/.pnpm/zod@3.25.45/node_modules/zod/dist/esm/v3/locales/en.js
 var errorMap = (issue, _ctx) => {
   let message;
   switch (issue.code) {
@@ -20470,13 +20470,13 @@ var errorMap = (issue, _ctx) => {
 };
 var en_default = errorMap;
 
-// node_modules/.pnpm/zod@3.25.67/node_modules/zod/dist/esm/v3/errors.js
+// node_modules/.pnpm/zod@3.25.45/node_modules/zod/dist/esm/v3/errors.js
 var overrideErrorMap = en_default;
 function getErrorMap() {
   return overrideErrorMap;
 }
 
-// node_modules/.pnpm/zod@3.25.67/node_modules/zod/dist/esm/v3/helpers/parseUtil.js
+// node_modules/.pnpm/zod@3.25.45/node_modules/zod/dist/esm/v3/helpers/parseUtil.js
 var makeIssue = (params) => {
   const { data, path: path3, errorMaps, issueData } = params;
   const fullPath = [...path3, ...issueData.path || []];
@@ -20585,14 +20585,14 @@ var isDirty = (x) => x.status === "dirty";
 var isValid = (x) => x.status === "valid";
 var isAsync = (x) => typeof Promise !== "undefined" && x instanceof Promise;
 
-// node_modules/.pnpm/zod@3.25.67/node_modules/zod/dist/esm/v3/helpers/errorUtil.js
+// node_modules/.pnpm/zod@3.25.45/node_modules/zod/dist/esm/v3/helpers/errorUtil.js
 var errorUtil;
 (function(errorUtil2) {
   errorUtil2.errToObj = (message) => typeof message === "string" ? { message } : message || {};
   errorUtil2.toString = (message) => typeof message === "string" ? message : message?.message;
 })(errorUtil || (errorUtil = {}));
 
-// node_modules/.pnpm/zod@3.25.67/node_modules/zod/dist/esm/v3/types.js
+// node_modules/.pnpm/zod@3.25.45/node_modules/zod/dist/esm/v3/types.js
 var ParseInputLazyPath = class {
   constructor(parent, value, path3, key) {
     this._cachedPath = [];
@@ -24004,7 +24004,7 @@ function untildify(pathWithTilde) {
   return homeDirectory ? pathWithTilde.replace(/^~(?=$|\/|\\)/, homeDirectory) : pathWithTilde;
 }
 
-// node_modules/.pnpm/smol-toml@1.4.0/node_modules/smol-toml/dist/error.js
+// node_modules/.pnpm/smol-toml@1.3.4/node_modules/smol-toml/dist/error.js
 function getLineColFromPtr(string, ptr) {
   let lines = string.slice(0, ptr).split(/\r\n|\n|\r/g);
   return [lines.length, lines.pop().length + 1];
@@ -24044,7 +24044,7 @@ ${codeblock}`, options2);
   }
 };
 
-// node_modules/.pnpm/smol-toml@1.4.0/node_modules/smol-toml/dist/util.js
+// node_modules/.pnpm/smol-toml@1.3.4/node_modules/smol-toml/dist/util.js
 function indexOfNewline(str, start = 0, end = str.length) {
   let idx = str.indexOf("\n", start);
   if (str[idx - 1] === "\r")
@@ -24112,7 +24112,7 @@ function getStringEnd(str, seek) {
   return seek;
 }
 
-// node_modules/.pnpm/smol-toml@1.4.0/node_modules/smol-toml/dist/date.js
+// node_modules/.pnpm/smol-toml@1.3.4/node_modules/smol-toml/dist/date.js
 var DATE_TIME_RE = /^(\d{4}-\d{2}-\d{2})?[T ]?(?:(\d{2}):\d{2}:\d{2}(?:\.\d+)?)?(Z|[-+]\d{2}:\d{2})?$/i;
 var _hasDate, _hasTime, _offset;
 var _TomlDate = class _TomlDate extends Date {
@@ -24209,7 +24209,7 @@ _hasTime = new WeakMap();
 _offset = new WeakMap();
 var TomlDate = _TomlDate;
 
-// node_modules/.pnpm/smol-toml@1.4.0/node_modules/smol-toml/dist/primitive.js
+// node_modules/.pnpm/smol-toml@1.3.4/node_modules/smol-toml/dist/primitive.js
 var INT_REGEX = /^((0x[0-9a-fA-F](_?[0-9a-fA-F])*)|(([+-]|0[ob])?\d(_?\d)*))$/;
 var FLOAT_REGEX = /^[+-]?\d(_?\d)*(\.\d(_?\d)*)?([eE][+-]?\d(_?\d)*)?$/;
 var LEADING_ZERO = /^[+-]?0[0-9_]/;
@@ -24296,7 +24296,7 @@ function parseString(str, ptr = 0, endPtr = str.length) {
   }
   return parsed + str.slice(sliceStart, endPtr - 1);
 }
-function parseValue(value, toml, ptr, integersAsBigInt) {
+function parseValue(value, toml, ptr) {
   if (value === "true")
     return true;
   if (value === "false")
@@ -24308,36 +24308,31 @@ function parseValue(value, toml, ptr, integersAsBigInt) {
   if (value === "nan" || value === "+nan" || value === "-nan")
     return NaN;
   if (value === "-0")
-    return integersAsBigInt ? 0n : 0;
-  let isInt = INT_REGEX.test(value);
-  if (isInt || FLOAT_REGEX.test(value)) {
+    return 0;
+  let isInt;
+  if ((isInt = INT_REGEX.test(value)) || FLOAT_REGEX.test(value)) {
     if (LEADING_ZERO.test(value)) {
       throw new TomlError("leading zeroes are not allowed", {
         toml,
         ptr
       });
     }
-    value = value.replace(/_/g, "");
-    let numeric = +value;
+    let numeric = +value.replace(/_/g, "");
     if (isNaN(numeric)) {
       throw new TomlError("invalid number", {
         toml,
         ptr
       });
     }
-    if (isInt) {
-      if ((isInt = !Number.isSafeInteger(numeric)) && !integersAsBigInt) {
-        throw new TomlError("integer value cannot be represented losslessly", {
-          toml,
-          ptr
-        });
-      }
-      if (isInt || integersAsBigInt)
-        numeric = BigInt(value);
+    if (isInt && !Number.isSafeInteger(numeric)) {
+      throw new TomlError("integer value cannot be represented losslessly", {
+        toml,
+        ptr
+      });
     }
     return numeric;
   }
-  const date = new TomlDate(value);
+  let date = new TomlDate(value);
   if (!date.isValid()) {
     throw new TomlError("invalid value", {
       toml,
@@ -24347,7 +24342,7 @@ function parseValue(value, toml, ptr, integersAsBigInt) {
   return date;
 }
 
-// node_modules/.pnpm/smol-toml@1.4.0/node_modules/smol-toml/dist/extract.js
+// node_modules/.pnpm/smol-toml@1.3.4/node_modules/smol-toml/dist/extract.js
 function sliceAndTrimEndOf(str, startPtr, endPtr, allowNewLines) {
   let value = str.slice(startPtr, endPtr);
   let commentIdx = value.indexOf("#");
@@ -24367,7 +24362,7 @@ function sliceAndTrimEndOf(str, startPtr, endPtr, allowNewLines) {
   }
   return [trimmed, commentIdx];
 }
-function extractValue(str, ptr, end, depth, integersAsBigInt) {
+function extractValue(str, ptr, end, depth = -1) {
   if (depth === 0) {
     throw new TomlError("document contains excessively nested structures. aborting.", {
       toml: str,
@@ -24376,7 +24371,7 @@ function extractValue(str, ptr, end, depth, integersAsBigInt) {
   }
   let c = str[ptr];
   if (c === "[" || c === "{") {
-    let [value, endPtr2] = c === "[" ? parseArray(str, ptr, depth, integersAsBigInt) : parseInlineTable(str, ptr, depth, integersAsBigInt);
+    let [value, endPtr2] = c === "[" ? parseArray(str, ptr, depth) : parseInlineTable(str, ptr, depth);
     let newPtr = end ? skipUntil(str, endPtr2, ",", end) : endPtr2;
     if (endPtr2 - newPtr && end === "}") {
       let nextNewLine = indexOfNewline(str, endPtr2, newPtr);
@@ -24418,12 +24413,12 @@ function extractValue(str, ptr, end, depth, integersAsBigInt) {
     endPtr += +(str[endPtr] === ",");
   }
   return [
-    parseValue(slice[0], str, ptr, integersAsBigInt),
+    parseValue(slice[0], str, ptr),
     endPtr
   ];
 }
 
-// node_modules/.pnpm/smol-toml@1.4.0/node_modules/smol-toml/dist/struct.js
+// node_modules/.pnpm/smol-toml@1.3.4/node_modules/smol-toml/dist/struct.js
 var KEY_PART_RE = /^[a-zA-Z0-9-_]+[ \t]*$/;
 function parseKey(str, ptr, end = "=") {
   let dot = ptr - 1;
@@ -24492,20 +24487,28 @@ function parseKey(str, ptr, end = "=") {
   } while (dot + 1 && dot < endPtr);
   return [parsed, skipVoid(str, endPtr + 1, true, true)];
 }
-function parseInlineTable(str, ptr, depth, integersAsBigInt) {
+function parseInlineTable(str, ptr, depth = -1) {
   let res = {};
   let seen = /* @__PURE__ */ new Set();
   let c;
   let comma = 0;
   ptr++;
   while ((c = str[ptr++]) !== "}" && c) {
-    let err = { toml: str, ptr: ptr - 1 };
     if (c === "\n") {
-      throw new TomlError("newlines are not allowed in inline tables", err);
+      throw new TomlError("newlines are not allowed in inline tables", {
+        toml: str,
+        ptr: ptr - 1
+      });
     } else if (c === "#") {
-      throw new TomlError("inline tables cannot contain comments", err);
+      throw new TomlError("inline tables cannot contain comments", {
+        toml: str,
+        ptr: ptr - 1
+      });
     } else if (c === ",") {
-      throw new TomlError("expected key-value, found comma", err);
+      throw new TomlError("expected key-value, found comma", {
+        toml: str,
+        ptr: ptr - 1
+      });
     } else if (c !== " " && c !== "	") {
       let k;
       let t = res;
@@ -24531,7 +24534,7 @@ function parseInlineTable(str, ptr, depth, integersAsBigInt) {
           ptr
         });
       }
-      let [value, valueEndPtr] = extractValue(str, keyEndPtr, "}", depth - 1, integersAsBigInt);
+      let [value, valueEndPtr] = extractValue(str, keyEndPtr, "}", depth - 1);
       seen.add(value);
       t[k] = value;
       ptr = valueEndPtr;
@@ -24552,7 +24555,7 @@ function parseInlineTable(str, ptr, depth, integersAsBigInt) {
   }
   return [res, ptr];
 }
-function parseArray(str, ptr, depth, integersAsBigInt) {
+function parseArray(str, ptr, depth = -1) {
   let res = [];
   let c;
   ptr++;
@@ -24565,7 +24568,7 @@ function parseArray(str, ptr, depth, integersAsBigInt) {
     } else if (c === "#")
       ptr = skipComment(str, ptr);
     else if (c !== " " && c !== "	" && c !== "\n" && c !== "\r") {
-      let e = extractValue(str, ptr - 1, "]", depth - 1, integersAsBigInt);
+      let e = extractValue(str, ptr - 1, "]", depth - 1);
       res.push(e[0]);
       ptr = e[1];
     }
@@ -24579,7 +24582,7 @@ function parseArray(str, ptr, depth, integersAsBigInt) {
   return [res, ptr];
 }
 
-// node_modules/.pnpm/smol-toml@1.4.0/node_modules/smol-toml/dist/parse.js
+// node_modules/.pnpm/smol-toml@1.3.4/node_modules/smol-toml/dist/parse.js
 function peekTable(key, table, meta, type) {
   let t = table;
   let m = meta;
@@ -24639,7 +24642,8 @@ function peekTable(key, table, meta, type) {
   }
   return [k, t, state.c];
 }
-function parse(toml, { maxDepth = 1e3, integersAsBigInt } = {}) {
+function parse(toml, opts) {
+  let maxDepth = opts?.maxDepth ?? 1e3;
   let res = {};
   let meta = {};
   let tbl = res;
@@ -24688,7 +24692,7 @@ function parse(toml, { maxDepth = 1e3, integersAsBigInt } = {}) {
           ptr
         });
       }
-      let v = extractValue(toml, k[1], void 0, maxDepth, integersAsBigInt);
+      let v = extractValue(toml, k[1], void 0, maxDepth);
       p[1][p[0]] = v[0];
       ptr = v[1];
     }
@@ -24743,6 +24747,9 @@ var parseOrUndefinedList = (key, schema) => {
 var validateInputs = (inputs) => {
   if (inputs.pixiVersion && inputs.pixiUrl) {
     throw new Error("You need to specify either pixi-version or pixi-url");
+  }
+  if (inputs.pixiUrlBearerToken && !inputs.pixiUrl) {
+    throw new Error("You need to specify pixi-url when using pixi-url-bearer-token");
   }
   if (inputs.cacheKey !== void 0 && inputs.cache === false) {
     throw new Error("Cannot specify cache key without caching");
@@ -24822,7 +24829,7 @@ var determinePixiInstallation = (pixiUrlOrVersionSet, pixiBinPath) => {
 };
 var inferOptions = (inputs) => {
   const runInstall = inputs.runInstall ?? true;
-  const pixiSource = inputs.pixiVersion ? { version: inputs.pixiVersion } : inputs.pixiUrl ? { url: inputs.pixiUrl } : { version: "latest" };
+  const pixiSource = inputs.pixiVersion ? { version: inputs.pixiVersion } : inputs.pixiUrl ? { url: inputs.pixiUrl, bearerToken: inputs.pixiUrlBearerToken } : { version: "latest" };
   const { downloadPixi, pixiBinPath } = determinePixiInstallation(
     !!inputs.pixiVersion || !!inputs.pixiUrl,
     inputs.pixiBinPath
@@ -24913,6 +24920,7 @@ var getOptions = () => {
       "pixi-version must either be `latest` or a version string matching `vX.Y.Z`."
     ),
     pixiUrl: parseOrUndefined("pixi-url", stringType().url()),
+    pixiUrlBearerToken: parseOrUndefined("pixi-url-bearer-token", stringType()),
     logLevel: parseOrUndefined(
       "log-level",
       logLevelSchema,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-pixi",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "private": true,
   "description": "Action to set up the pixi package manager.",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,12 +12,14 @@ import { activateEnvironment } from './activate'
 
 const downloadPixi = (source: PixiSource) => {
   const url = 'version' in source ? getPixiUrlFromVersion(source.version) : source.url
+  const auth = 'bearerToken' in source && source.bearerToken ? `Bearer ${source.bearerToken}` : ''
   return core.group('Downloading Pixi', () => {
     core.debug('Installing pixi')
     core.debug(`Downloading pixi from ${url}`)
+    core.debug(`Using Bearer auth: ${auth ? 'yes' : 'no'}`)
     return fs
       .mkdir(path.dirname(options.pixiBinPath), { recursive: true })
-      .then(() => downloadTool(url, options.pixiBinPath))
+      .then(() => downloadTool(url, options.pixiBinPath, auth))
       .then((_downloadPath) => fs.chmod(options.pixiBinPath, 0o755))
       .then(() => {
         core.info(`Pixi installed to ${options.pixiBinPath}`)

--- a/src/options.ts
+++ b/src/options.ts
@@ -11,6 +11,7 @@ import which from 'which'
 type Inputs = Readonly<{
   pixiVersion?: string
   pixiUrl?: string
+  pixiUrlBearerToken?: string
   logLevel?: LogLevel
   manifestPath?: string
   runInstall?: boolean
@@ -39,6 +40,7 @@ export type PixiSource =
     }
   | {
       url: string
+      bearerToken?: string
     }
 
 type Auth = {
@@ -133,6 +135,9 @@ const validateInputs = (inputs: Inputs): void => {
   if (inputs.pixiVersion && inputs.pixiUrl) {
     throw new Error('You need to specify either pixi-version or pixi-url')
   }
+  if (inputs.pixiUrlBearerToken && !inputs.pixiUrl) {
+    throw new Error('You need to specify pixi-url when using pixi-url-bearer-token')
+  }
   if (inputs.cacheKey !== undefined && inputs.cache === false) {
     throw new Error('Cannot specify cache key without caching')
   }
@@ -223,7 +228,7 @@ const inferOptions = (inputs: Inputs): Options => {
   const pixiSource = inputs.pixiVersion
     ? { version: inputs.pixiVersion }
     : inputs.pixiUrl
-      ? { url: inputs.pixiUrl }
+      ? { url: inputs.pixiUrl, bearerToken: inputs.pixiUrlBearerToken }
       : { version: 'latest' }
 
   const { downloadPixi, pixiBinPath } = determinePixiInstallation(
@@ -340,6 +345,7 @@ const getOptions = () => {
       'pixi-version must either be `latest` or a version string matching `vX.Y.Z`.'
     ),
     pixiUrl: parseOrUndefined('pixi-url', z.string().url()),
+    pixiUrlBearerToken: parseOrUndefined('pixi-url-bearer-token', z.string()),
     logLevel: parseOrUndefined(
       'log-level',
       logLevelSchema,


### PR DESCRIPTION
Especially in restricted corporate environments, it might be desirable to download pixi from an internal mirror that requires authentication. This PR adds an input `pixi-url-bearer-token` allowing you to supply a bearer token for the tool download from `pixi-url`.


If updating documentation:

- [x] Updated documentation in https://github.com/prefix-dev/pixi/blob/main/docs/integration/ci/github_actions.md as well -> yes, https://github.com/prefix-dev/pixi/pull/4127
