### PR TITLE
feat: Replace pixi-url-bearer-token by pixi-url-headers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -190,7 +190,7 @@ jobs:
           pixi-url: https://github.com/prefix-dev/pixi/releases/download/v0.14.0/pixi-x86_64-unknown-linux-musl
       - run: pixi --version | grep -q "pixi 0.14.0"
 
-  pixi-url-bearer-token:
+  pixi-url-headers-bearer:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -216,7 +216,7 @@ jobs:
         with:
           cache: false
           pixi-url: http://localhost:8080/pixi
-          pixi-url-bearer-token: wrongtoken
+          pixi-url-headers: '{"Authorization": "Bearer wrongtoken"}'
         continue-on-error: true
       - name: Fail if wrong token did not fail
         run: |
@@ -228,7 +228,7 @@ jobs:
         with:
           cache: false
           pixi-url: http://localhost:8080/pixi
-          pixi-url-bearer-token: s3cr3tT0k3nABC123
+          pixi-url-headers: '{"Authorization": "Bearer s3cr3tT0k3nABC123"}'
       - run: pixi --version | grep -q "pixi 0.14.0"
 
   pixi-url-custom-template-no-version:

--- a/README.md
+++ b/README.md
@@ -396,13 +396,13 @@ If you only want to install pixi and not install the current project, you can us
 ### Download pixi from a custom URL
 
 You can also download pixi from a custom URL by setting the `pixi-url` input argument.
-Optionally, you can combine this with the `pixi-url-bearer-token` input argument to authenticate the download request.
+Optionally, you can combine this with the `pixi-url-headers` input argument to supply additional headers for the download request, such as a bearer token.
 
 ```yml
 - uses: prefix-dev/setup-pixi@v0.8.13
   with:
     pixi-url: https://pixi-mirror.example.com/releases/download/v0.48.0/pixi-x86_64-unknown-linux-musl
-    pixi-url-bearer-token: ${{ secrets.PIXI_MIRROR_BEARER_TOKEN }}
+    pixi-url-headers: '{"Authorization": "Bearer ${{ secrets.PIXI_MIRROR_BEARER_TOKEN }}"}'
 ```
 
 The `pixi-url` input argument can also be a [Handlebars](https://handlebarsjs.com/) template string.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ GitHub Action to set up the [pixi](https://github.com/prefix-dev/pixi) package m
 ## Usage
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.13
+- uses: prefix-dev/setup-pixi@v0.8.14
   with:
     pixi-version: v0.49.0
 
@@ -35,7 +35,7 @@ GitHub Action to set up the [pixi](https://github.com/prefix-dev/pixi) package m
 
 > [!WARNING]
 > Since pixi is not yet stable, the API of this action may change between minor versions.
-> Please pin the versions of this action to a specific version (i.e., `prefix-dev/setup-pixi@v0.8.13`) to avoid breaking changes.
+> Please pin the versions of this action to a specific version (i.e., `prefix-dev/setup-pixi@v0.8.14`) to avoid breaking changes.
 > You can automatically update the version of this action by using [Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot).
 >
 > Put the following in your `.github/dependabot.yml` file to enable Dependabot for your GitHub Actions:
@@ -74,7 +74,7 @@ In order to not exceed the [10 GB cache size limit](https://docs.github.com/en/a
 This can be done by setting the `cache-write` argument.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.13
+- uses: prefix-dev/setup-pixi@v0.8.14
   with:
     cache: true
     cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
@@ -119,7 +119,7 @@ test:
       environment: [py311, py312]
   steps:
     - uses: actions/checkout@v4
-    - uses: prefix-dev/setup-pixi@v0.8.13
+    - uses: prefix-dev/setup-pixi@v0.8.14
       with:
         environments: ${{ matrix.environment }}
 ```
@@ -129,7 +129,7 @@ test:
 The following example will install both the `py311` and the `py312` environment on the runner.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.13
+- uses: prefix-dev/setup-pixi@v0.8.14
   with:
     # separated by spaces
     environments: >-
@@ -165,7 +165,7 @@ Specify the token using the `auth-token` input argument.
 This form of authentication (bearer token in the request headers) is mainly used at [prefix.dev](https://prefix.dev).
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.13
+- uses: prefix-dev/setup-pixi@v0.8.14
   with:
     auth-host: prefix.dev
     auth-token: ${{ secrets.PREFIX_DEV_TOKEN }}
@@ -177,7 +177,7 @@ Specify the username and password using the `auth-username` and `auth-password` 
 This form of authentication (HTTP Basic Auth) is used in some enterprise environments with [artifactory](https://jfrog.com/artifactory) for example.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.13
+- uses: prefix-dev/setup-pixi@v0.8.14
   with:
     auth-host: custom-artifactory.com
     auth-username: ${{ secrets.PIXI_USERNAME }}
@@ -190,7 +190,7 @@ Specify the conda-token using the `auth-conda-token` input argument.
 This form of authentication (token is encoded in URL: `https://my-quetz-instance.com/t/<token>/get/custom-channel`) is used at [anaconda.org](https://anaconda.org) or with [quetz instances](https://github.com/mamba-org/quetz).
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.13
+- uses: prefix-dev/setup-pixi@v0.8.14
   with:
     auth-host: anaconda.org # or my-quetz-instance.com
     auth-conda-token: ${{ secrets.CONDA_TOKEN }}
@@ -202,7 +202,7 @@ Specify the S3 key pair using the `auth-access-key-id` and `auth-secret-access-k
 You can also specify the session token using the `auth-session-token` input argument.
 
 ```yaml
-- uses: prefix-dev/setup-pixi@v0.8.13
+- uses: prefix-dev/setup-pixi@v0.8.14
   with:
     auth-host: s3://my-s3-bucket
     auth-s3-access-key-id: ${{ secrets.ACCESS_KEY_ID }}
@@ -274,7 +274,7 @@ To this end, `setup-pixi` adds all environment variables set when executing `pix
 As a result, all installed binaries can be accessed without having to call `pixi run`.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.13
+- uses: prefix-dev/setup-pixi@v0.8.14
   with:
     activate-environment: true
 ```
@@ -282,7 +282,7 @@ As a result, all installed binaries can be accessed without having to call `pixi
 If you are installing multiple environments, you will need to specify the name of the environment that you want to be activated.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.13
+- uses: prefix-dev/setup-pixi@v0.8.14
   with:
     environments: >-
       py311
@@ -299,7 +299,7 @@ You can specify whether `setup-pixi` should run `pixi install --frozen` or `pixi
 See the [official documentation](https://prefix.dev/docs/pixi/cli#install) for more information about the `--frozen` and `--locked` flags.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.13
+- uses: prefix-dev/setup-pixi@v0.8.14
   with:
     locked: true
     # or
@@ -318,7 +318,7 @@ The first one is the debug logging of the action itself.
 This can be enabled by running the action with the `RUNNER_DEBUG` environment variable set to `true`.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.13
+- uses: prefix-dev/setup-pixi@v0.8.14
   env:
     RUNNER_DEBUG: true
 ```
@@ -336,7 +336,7 @@ The second type is the debug logging of the pixi executable.
 This can be specified by setting the `log-level` input.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.13
+- uses: prefix-dev/setup-pixi@v0.8.14
   with:
     # one of `q`, `default`, `v`, `vv`, or `vvv`.
     log-level: vvv
@@ -362,7 +362,7 @@ If nothing is specified, `post-cleanup` will default to `true`.
 On self-hosted runners, you also might want to alter the default pixi install location to a temporary location. You can use `pixi-bin-path: ${{ runner.temp }}/bin/pixi` to do this.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.13
+- uses: prefix-dev/setup-pixi@v0.8.14
   with:
     post-cleanup: true
     # ${{ runner.temp }}\Scripts\pixi.exe on Windows
@@ -378,7 +378,7 @@ You can also use a preinstalled local version of pixi on the runner by not setti
 This can be overwritten by setting the `manifest-path` input argument.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.13
+- uses: prefix-dev/setup-pixi@v0.8.14
   with:
     manifest-path: pyproject.toml
 ```
@@ -388,7 +388,7 @@ This can be overwritten by setting the `manifest-path` input argument.
 If you only want to install pixi and not install the current project, you can use the `run-install` option.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.13
+- uses: prefix-dev/setup-pixi@v0.8.14
   with:
     run-install: false
 ```
@@ -399,7 +399,7 @@ You can also download pixi from a custom URL by setting the `pixi-url` input arg
 Optionally, you can combine this with the `pixi-url-headers` input argument to supply additional headers for the download request, such as a bearer token.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.13
+- uses: prefix-dev/setup-pixi@v0.8.14
   with:
     pixi-url: https://pixi-mirror.example.com/releases/download/v0.48.0/pixi-x86_64-unknown-linux-musl
     pixi-url-headers: '{"Authorization": "Bearer ${{ secrets.PIXI_MIRROR_BEARER_TOKEN }}"}'
@@ -415,7 +415,7 @@ It will be rendered with the following variables:
 By default, `pixi-url` is equivalent to the following template:
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.13
+- uses: prefix-dev/setup-pixi@v0.8.14
   with:
     pixi-url: |
       {{#if latest~}}

--- a/action.yml
+++ b/action.yml
@@ -10,8 +10,8 @@ inputs:
     description: Version of pixi to install
   pixi-url:
     description: URL of pixi to install. Can be a Handlebars template receiving `version`, `latest`, and `pixiFile` as variables.
-  pixi-url-bearer-token:
-    description: Bearer token to use for authentication when downloading pixi from a URL.
+  pixi-url-headers:
+    description: Headers to use when fetching the pixi binary from `pixi-url`. Should be a JSON string.
   log-level:
     description: |
       Log level for the pixi CLI.

--- a/dist/index.js
+++ b/dist/index.js
@@ -74830,8 +74830,8 @@ var parseOrUndefinedList = (key, schema) => {
   return input.split(" ").map((s) => schema.parse(s)).filter((s) => s !== "");
 };
 var validateInputs = (inputs) => {
-  if (inputs.pixiUrlBearerToken && !inputs.pixiUrl) {
-    throw new Error("You need to specify pixi-url when using pixi-url-bearer-token");
+  if (inputs.pixiUrlHeaders && !inputs.pixiUrl) {
+    throw new Error("You need to specify pixi-url when using pixi-url-headers");
   }
   if (inputs.cacheKey !== void 0 && inputs.cache === false) {
     throw new Error("Cannot specify cache key without caching");
@@ -74913,7 +74913,7 @@ var inferOptions = (inputs) => {
   const runInstall = inputs.runInstall ?? true;
   const pixiSource = {
     urlTemplate: inputs.pixiUrl ?? DEFAULT_PIXI_URL_TEMPLATE,
-    bearerToken: inputs.pixiUrlBearerToken,
+    headers: inputs.pixiUrlHeaders,
     version: inputs.pixiVersion ?? "latest"
   };
   const { downloadPixi: downloadPixi2, pixiBinPath } = determinePixiInstallation(
@@ -75006,7 +75006,7 @@ var getOptions = () => {
       "pixi-version must either be `latest` or a version string matching `vX.Y.Z`."
     ),
     pixiUrl: parseOrUndefined("pixi-url", stringType()),
-    pixiUrlBearerToken: parseOrUndefined("pixi-url-bearer-token", stringType()),
+    pixiUrlHeaders: parseOrUndefinedJSON("pixi-url-headers", recordType(stringType(), stringType())),
     logLevel: parseOrUndefined(
       "log-level",
       logLevelSchema,
@@ -75182,12 +75182,11 @@ var activateEnvironment = async (environment) => {
 // src/main.ts
 var downloadPixi = (source) => {
   const url2 = renderPixiUrl(source.urlTemplate, source.version);
-  const auth = "bearerToken" in source && source.bearerToken ? `Bearer ${source.bearerToken}` : "";
   return core5.group("Downloading Pixi", () => {
     core5.debug("Installing pixi");
     core5.debug(`Downloading pixi from ${url2}`);
-    core5.debug(`Using Bearer auth: ${auth ? "yes" : "no"}`);
-    return import_promises2.default.mkdir(import_path3.default.dirname(options.pixiBinPath), { recursive: true }).then(() => (0, import_tool_cache.downloadTool)(url2, options.pixiBinPath, auth)).then((_downloadPath) => import_promises2.default.chmod(options.pixiBinPath, 493)).then(() => {
+    core5.debug(`Using headers: ${JSON.stringify(source.headers)}`);
+    return import_promises2.default.mkdir(import_path3.default.dirname(options.pixiBinPath), { recursive: true }).then(() => (0, import_tool_cache.downloadTool)(url2, options.pixiBinPath, void 0, source.headers)).then((_downloadPath) => import_promises2.default.chmod(options.pixiBinPath, 493)).then(() => {
       core5.info(`Pixi installed to ${options.pixiBinPath}`);
     });
   });

--- a/dist/post.js
+++ b/dist/post.js
@@ -30618,8 +30618,8 @@ var parseOrUndefinedList = (key, schema) => {
   return input.split(" ").map((s) => schema.parse(s)).filter((s) => s !== "");
 };
 var validateInputs = (inputs) => {
-  if (inputs.pixiUrlBearerToken && !inputs.pixiUrl) {
-    throw new Error("You need to specify pixi-url when using pixi-url-bearer-token");
+  if (inputs.pixiUrlHeaders && !inputs.pixiUrl) {
+    throw new Error("You need to specify pixi-url when using pixi-url-headers");
   }
   if (inputs.cacheKey !== void 0 && inputs.cache === false) {
     throw new Error("Cannot specify cache key without caching");
@@ -30701,7 +30701,7 @@ var inferOptions = (inputs) => {
   const runInstall = inputs.runInstall ?? true;
   const pixiSource = {
     urlTemplate: inputs.pixiUrl ?? DEFAULT_PIXI_URL_TEMPLATE,
-    bearerToken: inputs.pixiUrlBearerToken,
+    headers: inputs.pixiUrlHeaders,
     version: inputs.pixiVersion ?? "latest"
   };
   const { downloadPixi, pixiBinPath } = determinePixiInstallation(
@@ -30794,7 +30794,7 @@ var getOptions = () => {
       "pixi-version must either be `latest` or a version string matching `vX.Y.Z`."
     ),
     pixiUrl: parseOrUndefined("pixi-url", stringType()),
-    pixiUrlBearerToken: parseOrUndefined("pixi-url-bearer-token", stringType()),
+    pixiUrlHeaders: parseOrUndefinedJSON("pixi-url-headers", recordType(stringType(), stringType())),
     logLevel: parseOrUndefined(
       "log-level",
       logLevelSchema,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-pixi",
-  "version": "0.8.13",
+  "version": "0.8.14",
   "private": true,
   "description": "Action to set up the pixi package manager.",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,14 +12,13 @@ import { activateEnvironment } from './activate'
 
 const downloadPixi = (source: PixiSource) => {
   const url = renderPixiUrl(source.urlTemplate, source.version)
-  const auth = 'bearerToken' in source && source.bearerToken ? `Bearer ${source.bearerToken}` : ''
   return core.group('Downloading Pixi', () => {
     core.debug('Installing pixi')
     core.debug(`Downloading pixi from ${url}`)
-    core.debug(`Using Bearer auth: ${auth ? 'yes' : 'no'}`)
+    core.debug(`Using headers: ${JSON.stringify(source.headers)}`)
     return fs
       .mkdir(path.dirname(options.pixiBinPath), { recursive: true })
-      .then(() => downloadTool(url, options.pixiBinPath, auth))
+      .then(() => downloadTool(url, options.pixiBinPath, undefined, source.headers))
       .then((_downloadPath) => fs.chmod(options.pixiBinPath, 0o755))
       .then(() => {
         core.info(`Pixi installed to ${options.pixiBinPath}`)

--- a/src/options.ts
+++ b/src/options.ts
@@ -12,7 +12,7 @@ import { DEFAULT_PIXI_URL_TEMPLATE } from './util'
 type Inputs = Readonly<{
   pixiVersion?: string
   pixiUrl?: string
-  pixiUrlBearerToken?: string
+  pixiUrlHeaders?: NodeJS.Dict<string>
   logLevel?: LogLevel
   manifestPath?: string
   runInstall?: boolean
@@ -37,7 +37,7 @@ type Inputs = Readonly<{
 
 export interface PixiSource {
   urlTemplate: string
-  bearerToken?: string
+  headers?: NodeJS.Dict<string>
   version: string
 }
 
@@ -148,8 +148,8 @@ const parseOrUndefinedList = <T>(key: string, schema: z.ZodSchema<T>): T[] | und
 }
 
 const validateInputs = (inputs: Inputs): void => {
-  if (inputs.pixiUrlBearerToken && !inputs.pixiUrl) {
-    throw new Error('You need to specify pixi-url when using pixi-url-bearer-token')
+  if (inputs.pixiUrlHeaders && !inputs.pixiUrl) {
+    throw new Error('You need to specify pixi-url when using pixi-url-headers')
   }
   if (inputs.cacheKey !== undefined && inputs.cache === false) {
     throw new Error('Cannot specify cache key without caching')
@@ -240,7 +240,7 @@ const inferOptions = (inputs: Inputs): Options => {
   const runInstall = inputs.runInstall ?? true
   const pixiSource: PixiSource = {
     urlTemplate: inputs.pixiUrl ?? DEFAULT_PIXI_URL_TEMPLATE,
-    bearerToken: inputs.pixiUrlBearerToken,
+    headers: inputs.pixiUrlHeaders,
     version: inputs.pixiVersion ?? 'latest'
   }
 
@@ -358,7 +358,7 @@ const getOptions = () => {
       'pixi-version must either be `latest` or a version string matching `vX.Y.Z`.'
     ),
     pixiUrl: parseOrUndefined('pixi-url', z.string()),
-    pixiUrlBearerToken: parseOrUndefined('pixi-url-bearer-token', z.string()),
+    pixiUrlHeaders: parseOrUndefinedJSON('pixi-url-headers', z.record(z.string(), z.string())),
     logLevel: parseOrUndefined(
       'log-level',
       logLevelSchema,


### PR DESCRIPTION
If updating documentation:

- [x] Updated documentation in https://github.com/prefix-dev/pixi/blob/main/docs/integration/ci/github_actions.md as well: https://github.com/prefix-dev/pixi/pull/4207
