### PR TITLE
chore: Bump to node 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -69,6 +69,6 @@ inputs:
       If `true`, the pixi environment, the pixi binary and the rattler files in ~/.rattler and ~/.cache/rattler are removed.
 
 runs:
-  using: node20
+  using: node24
   main: dist/index.js
   post: dist/post.js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-pixi",
-  "version": "0.8.14",
+  "version": "0.9.0",
   "private": true,
   "description": "Action to set up the pixi package manager.",
   "scripts": {


### PR DESCRIPTION
If updating documentation:

- [ ] Updated documentation in https://github.com/prefix-dev/pixi/blob/main/docs/integration/ci/github_actions.md as well
