### PR TITLE
fix: reuse existing pixi if version matches on re-download

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -71269,6 +71269,29 @@ var activateEnvironment = async (environment) => {
 };
 
 // src/main.ts
+var fileExists = async (p) => {
+  try {
+    await import_promises2.default.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+};
+var readInstalledPixiVersion = async (binPath) => {
+  try {
+    const { stdout, exitCode } = await executeGetOutput([binPath, "--version"], {
+      silent: true,
+      ignoreReturnCode: true
+    });
+    if (exitCode !== 0) {
+      return void 0;
+    }
+    const match2 = /\b(\d+\.\d+\.\d+\S*)/.exec(stdout);
+    return match2?.[1];
+  } catch {
+    return void 0;
+  }
+};
 var downloadPixi = async (source) => {
   const url2 = renderPixiUrl(source.urlTemplate, source.version);
   await group("Downloading Pixi", async () => {
@@ -71276,6 +71299,22 @@ var downloadPixi = async (source) => {
     debug(`Downloading pixi from ${url2}`);
     debug(`Using headers: ${JSON.stringify(source.headers)}`);
     await import_promises2.default.mkdir(import_path3.default.dirname(options.pixiBinPath), { recursive: true });
+    if (await fileExists(options.pixiBinPath)) {
+      if (source.version !== "latest") {
+        const installed = await readInstalledPixiVersion(options.pixiBinPath);
+        const requested = source.version.replace(/^v/, "");
+        if (installed && installed === requested) {
+          info(`Pixi ${installed} already installed at ${options.pixiBinPath}, skipping download`);
+          return;
+        }
+        info(
+          `Replacing existing pixi at ${options.pixiBinPath} (installed: ${installed ?? "unknown"}, requested: ${requested})`
+        );
+      } else {
+        info(`Replacing existing pixi at ${options.pixiBinPath} (requested: latest)`);
+      }
+      await import_promises2.default.rm(options.pixiBinPath, { force: true });
+    }
     await downloadTool(url2, options.pixiBinPath, void 0, source.headers);
     await import_promises2.default.chmod(options.pixiBinPath, 493);
     info(`Pixi installed to ${options.pixiBinPath}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,9 +6,37 @@ import * as core from '@actions/core'
 import { downloadTool } from '@actions/tool-cache'
 import type { PixiSource } from './options'
 import { options } from './options'
-import { execute, pixiCmd, renderPixiUrl } from './util'
+import { execute, executeGetOutput, pixiCmd, renderPixiUrl } from './util'
 import { tryRestoreGlobalCache, tryRestoreProjectCache, saveGlobalCache, saveProjectCache } from './cache'
 import { activateEnvironment } from './activate'
+
+const fileExists = async (p: string) => {
+  try {
+    await fs.access(p)
+    return true
+  } catch {
+    return false
+  }
+}
+
+// Returns the installed version (e.g. "0.67.2") or undefined if the binary
+// cannot be executed or the output does not match the expected format.
+const readInstalledPixiVersion = async (binPath: string) => {
+  try {
+    const { stdout, exitCode } = await executeGetOutput([binPath, '--version'], {
+      silent: true,
+      ignoreReturnCode: true
+    })
+    if (exitCode !== 0) {
+      return undefined
+    }
+    // `pixi --version` prints something like "pixi 0.67.2"
+    const match = /\b(\d+\.\d+\.\d+\S*)/.exec(stdout)
+    return match?.[1]
+  } catch {
+    return undefined
+  }
+}
 
 const downloadPixi = async (source: PixiSource) => {
   const url = renderPixiUrl(source.urlTemplate, source.version)
@@ -17,6 +45,29 @@ const downloadPixi = async (source: PixiSource) => {
     core.debug(`Downloading pixi from ${url}`)
     core.debug(`Using headers: ${JSON.stringify(source.headers)}`)
     await fs.mkdir(path.dirname(options.pixiBinPath), { recursive: true })
+
+    // If a previous step in this job already installed pixi at the same path,
+    // @actions/tool-cache's downloadTool will throw "Destination file path
+    // ... already exists". If the existing binary matches the requested
+    // version we can safely skip the download; otherwise remove it so the
+    // download can proceed. See prefix-dev/setup-pixi#107.
+    if (await fileExists(options.pixiBinPath)) {
+      if (source.version !== 'latest') {
+        const installed = await readInstalledPixiVersion(options.pixiBinPath)
+        const requested = source.version.replace(/^v/, '')
+        if (installed && installed === requested) {
+          core.info(`Pixi ${installed} already installed at ${options.pixiBinPath}, skipping download`)
+          return
+        }
+        core.info(
+          `Replacing existing pixi at ${options.pixiBinPath} (installed: ${installed ?? 'unknown'}, requested: ${requested})`
+        )
+      } else {
+        core.info(`Replacing existing pixi at ${options.pixiBinPath} (requested: latest)`)
+      }
+      await fs.rm(options.pixiBinPath, { force: true })
+    }
+
     await downloadTool(url, options.pixiBinPath, undefined, source.headers)
     await fs.chmod(options.pixiBinPath, 0o755)
     core.info(`Pixi installed to ${options.pixiBinPath}`)


### PR DESCRIPTION
## Summary

When this action runs more than once in the same job with the same `pixi-version`, the second invocation fails with:

```
Error: Destination file path /home/runner/.pixi/bin/pixi already exists
```

`determinePixiInstallation` (`src/options.ts`) takes the "download anyway" branch whenever `pixi-version` or `pixi-url` is set — any preinstalled pixi is ignored. `@actions/tool-cache`'s `downloadTool` then errors on the existing destination file.

This affects any workflow where a job composes two actions that each call `setup-pixi` — a common pattern when independent composite actions bring their own pixi manifests. The existing workarounds (don't set `pixi-version` on the second call, or give each call a distinct `pixi-bin-path`) are opaque — you have to find #107 to discover them, and they couple the consumer's workflow to knowledge about siblings.

## Change

Before downloading, check whether the destination binary already exists:
- If it does and `--version` matches the requested version, skip the download.
- Otherwise, remove the stale binary so the download can proceed.
- The `latest` case always replaces (we can't know whether it matches without a network call and there's no real cost to re-downloading).

This preserves existing behavior (including `pixi-bin-path` overrides and the "ignore preinstalled pixi" branch when versions differ), just makes the happy-path idempotent.

## Context

Closes #107 — the original suggestion in that issue was "check if the existing pixi version is the same as in the user input; only fail if the existing version does not match." That's what this implements.

## Test plan

- [ ] CI passes (existing test matrix)
- [ ] Manual: run the action twice in one job with the same `pixi-version` — second invocation logs `Pixi <version> already installed at ..., skipping download` and succeeds.
- [ ] Manual: run twice with different `pixi-version` values — second invocation logs `Replacing existing pixi ...` and re-downloads.

Happy to add an integration test in `test/` if you'd like — wasn't sure which directory best matches this scenario.