### PR TITLE
test persist-credentials: false

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -692,6 +692,27 @@ jobs:
           # Actual test
           ! grep -q '"*.custom-conda-registry.com"' "${RATTLER_AUTH_FILE}"
 
+  persist-credentials-false-smoke:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Move pixi.toml
+        run: mv test/default/* .
+      # Login with persist-credentials: false
+      - uses: ./
+        with:
+          cache: false
+          auth-host: https://custom-conda-registry.com
+          auth-token: custom-token
+          persist-credentials: false
+
+
   auth-token-install:
     strategy:
       matrix:


### PR DESCRIPTION
With the newest pixi 0.71, it seems that setup-pixi fails on logout if persist-credentials is set to false. This PR adds a test to reproduce the problem.