### PR TITLE
feat: change post-cleanup default to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ GitHub Action to set up the [pixi](https://github.com/prefix-dev/pixi) package m
 ## Usage
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.9.6
+- uses: prefix-dev/setup-pixi@v0.10.0
   with:
     pixi-version: v0.66.0
 
@@ -35,7 +35,7 @@ GitHub Action to set up the [pixi](https://github.com/prefix-dev/pixi) package m
 
 > [!WARNING]
 > Since pixi is not yet stable, the API of this action may change between minor versions.
-> Please pin the versions of this action to a specific version (i.e., `prefix-dev/setup-pixi@v0.9.6`) to avoid breaking changes.
+> Please pin the versions of this action to a specific version (i.e., `prefix-dev/setup-pixi@v0.10.0`) to avoid breaking changes.
 > You can automatically update the version of this action by using [Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot).
 >
 > Put the following in your `.github/dependabot.yml` file to enable Dependabot for your GitHub Actions:
@@ -79,7 +79,7 @@ In order to not exceed the [10 GB cache size limit](https://docs.github.com/en/a
 This can be done by setting the `cache-write` argument.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.9.6
+- uses: prefix-dev/setup-pixi@v0.10.0
   with:
     cache: true
     cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
@@ -124,7 +124,7 @@ test:
       environment: [py311, py312]
   steps:
     - uses: actions/checkout@v4
-    - uses: prefix-dev/setup-pixi@v0.9.6
+    - uses: prefix-dev/setup-pixi@v0.10.0
       with:
         environments: ${{ matrix.environment }}
 ```
@@ -134,7 +134,7 @@ test:
 The following example will install both the `py311` and the `py312` environment on the runner.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.9.6
+- uses: prefix-dev/setup-pixi@v0.10.0
   with:
     # separated by spaces
     environments: >-
@@ -157,7 +157,7 @@ For instance, the `keyring`, or `gcloud` executables. The following example show
 By default, global environments are not cached. You can enable caching by setting the `global-cache` input to `true`.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.9.6
+- uses: prefix-dev/setup-pixi@v0.10.0
   with:
     global-environments: |
       google-cloud-sdk
@@ -190,7 +190,7 @@ Specify the token using the `auth-token` input argument.
 This form of authentication (bearer token in the request headers) is mainly used at [prefix.dev](https://prefix.dev).
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.9.6
+- uses: prefix-dev/setup-pixi@v0.10.0
   with:
     auth-host: prefix.dev
     auth-token: ${{ secrets.PREFIX_DEV_TOKEN }}
@@ -202,7 +202,7 @@ Specify the username and password using the `auth-username` and `auth-password` 
 This form of authentication (HTTP Basic Auth) is used in some enterprise environments with [artifactory](https://jfrog.com/artifactory) for example.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.9.6
+- uses: prefix-dev/setup-pixi@v0.10.0
   with:
     auth-host: custom-artifactory.com
     auth-username: ${{ secrets.PIXI_USERNAME }}
@@ -215,7 +215,7 @@ Specify the conda-token using the `auth-conda-token` input argument.
 This form of authentication (token is encoded in URL: `https://my-quetz-instance.com/t/<token>/get/custom-channel`) is used at [anaconda.org](https://anaconda.org) or with [quetz instances](https://github.com/mamba-org/quetz).
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.9.6
+- uses: prefix-dev/setup-pixi@v0.10.0
   with:
     auth-host: anaconda.org # or my-quetz-instance.com
     auth-conda-token: ${{ secrets.CONDA_TOKEN }}
@@ -227,7 +227,7 @@ Specify the S3 key pair using the `auth-access-key-id` and `auth-secret-access-k
 You can also specify the session token using the `auth-session-token` input argument.
 
 ```yaml
-- uses: prefix-dev/setup-pixi@v0.9.6
+- uses: prefix-dev/setup-pixi@v0.10.0
   with:
     auth-host: s3://my-s3-bucket
     auth-s3-access-key-id: ${{ secrets.ACCESS_KEY_ID }}
@@ -246,7 +246,7 @@ then run `pixi auth logout <auth-host>` after `pixi install` has completed but b
 returns, so that later steps cannot reach the private channel anymore.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.9.6
+- uses: prefix-dev/setup-pixi@v0.10.0
   with:
     auth-host: prefix.dev
     auth-token: ${{ secrets.PREFIX_DEV_TOKEN }}
@@ -258,7 +258,7 @@ returns, so that later steps cannot reach the private channel anymore.
 You can specify whether to use keyring to look up credentials for PyPI.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.9.6
+- uses: prefix-dev/setup-pixi@v0.10.0
   with:
     pypi-keyring-provider: subprocess # one of 'subprocess', 'disabled'
 ```
@@ -326,7 +326,7 @@ To this end, `setup-pixi` adds all environment variables set when executing `pix
 As a result, all installed binaries can be accessed without having to call `pixi run`.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.9.6
+- uses: prefix-dev/setup-pixi@v0.10.0
   with:
     activate-environment: true
 ```
@@ -334,7 +334,7 @@ As a result, all installed binaries can be accessed without having to call `pixi
 If you are installing multiple environments, you will need to specify the name of the environment that you want to be activated.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.9.6
+- uses: prefix-dev/setup-pixi@v0.10.0
   with:
     environments: >-
       py311
@@ -351,7 +351,7 @@ You can specify whether `setup-pixi` should run `pixi install --frozen` or `pixi
 See the [official documentation](https://pixi.sh/latest/reference/cli/pixi/install/#update-options) for more information about the `--frozen` and `--locked` flags.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.9.6
+- uses: prefix-dev/setup-pixi@v0.10.0
   with:
     locked: true
     # or
@@ -370,7 +370,7 @@ The first one is the debug logging of the action itself.
 This can be enabled by running the action with the `RUNNER_DEBUG` environment variable set to `true`.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.9.6
+- uses: prefix-dev/setup-pixi@v0.10.0
   env:
     RUNNER_DEBUG: true
 ```
@@ -388,7 +388,7 @@ The second type is the debug logging of the pixi executable.
 This can be specified by setting the `log-level` input.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.9.6
+- uses: prefix-dev/setup-pixi@v0.10.0
   with:
     # one of `q`, `default`, `v`, `vv`, or `vvv`.
     log-level: vvv
@@ -409,12 +409,12 @@ If you set `post-cleanup` to `true`, the action will delete the following files:
 - the rattler cache
 - other rattler files in `~/.rattler`
 
-If nothing is specified, `post-cleanup` will default to `true`.
+If nothing is specified, `post-cleanup` will default to `false`.
 
 On self-hosted runners, you also might want to alter the default pixi install location to a temporary location. You can use `pixi-bin-path: ${{ runner.temp }}/bin/pixi` to do this.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.9.6
+- uses: prefix-dev/setup-pixi@v0.10.0
   with:
     post-cleanup: true
     # ${{ runner.temp }}\Scripts\pixi.exe on Windows
@@ -430,7 +430,7 @@ You can also use a preinstalled local version of pixi on the runner by not setti
 This can be overwritten by setting the `manifest-path` input argument.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.9.6
+- uses: prefix-dev/setup-pixi@v0.10.0
   with:
     manifest-path: pyproject.toml
 ```
@@ -440,7 +440,7 @@ This can be overwritten by setting the `manifest-path` input argument.
 If you're working with a monorepo where your pixi project is in a subdirectory, you can use the `working-directory` input to specify where pixi should look for manifest files (`pixi.toml` or `pyproject.toml`).
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.9.6
+- uses: prefix-dev/setup-pixi@v0.10.0
   with:
     working-directory: ./packages/my-project
 ```
@@ -459,7 +459,7 @@ This will make pixi look for `pixi.toml` or `pyproject.toml` in the `./packages/
 You can combine `working-directory` with `manifest-path` if needed:
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.9.6
+- uses: prefix-dev/setup-pixi@v0.10.0
   with:
     working-directory: ./packages/my-project
     manifest-path: custom-pixi.toml
@@ -470,7 +470,7 @@ You can combine `working-directory` with `manifest-path` if needed:
 If you only want to install pixi and not install the current project, you can use the `run-install` option.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.9.6
+- uses: prefix-dev/setup-pixi@v0.10.0
   with:
     run-install: false
 ```
@@ -481,7 +481,7 @@ You can also download pixi from a custom URL by setting the `pixi-url` input arg
 Optionally, you can combine this with the `pixi-url-headers` input argument to supply additional headers for the download request, such as a bearer token.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.9.6
+- uses: prefix-dev/setup-pixi@v0.10.0
   with:
     pixi-url: https://pixi-mirror.example.com/releases/download/v0.48.0/pixi-x86_64-unknown-linux-musl
     pixi-url-headers: '{"Authorization": "Bearer ${{ secrets.PIXI_MIRROR_BEARER_TOKEN }}"}'
@@ -497,7 +497,7 @@ It will be rendered with the following variables:
 By default, `pixi-url` is equivalent to the following template:
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.9.6
+- uses: prefix-dev/setup-pixi@v0.10.0
   with:
     pixi-url: |
       {{#if latest~}}

--- a/action.yml
+++ b/action.yml
@@ -90,7 +90,7 @@ inputs:
       options: disabled, subprocess
   post-cleanup:
     description: |
-      If the action should clean up after itself. Defaults to `true`.
+      If the action should clean up after itself. Defaults to `false`.
       If `true`, the pixi environment, the pixi binary and the rattler files in ~/.rattler and ~/.cache/rattler are removed.
 
 runs:

--- a/dist/index.js
+++ b/dist/index.js
@@ -57623,7 +57623,7 @@ var inferOptions = (inputs) => {
     s3SessionToken: inputs.authS3SessionToken,
     persistCredentials
   };
-  const postCleanup = inputs.postCleanup ?? true;
+  const postCleanup = inputs.postCleanup ?? false;
   const pypiKeyringProvider = inputs.pypiKeyringProvider;
   return {
     globalEnvironments: inputs.globalEnvironments,

--- a/dist/post.js
+++ b/dist/post.js
@@ -30504,7 +30504,7 @@ var inferOptions = (inputs) => {
     s3SessionToken: inputs.authS3SessionToken,
     persistCredentials
   };
-  const postCleanup = inputs.postCleanup ?? true;
+  const postCleanup = inputs.postCleanup ?? false;
   const pypiKeyringProvider = inputs.pypiKeyringProvider;
   return {
     globalEnvironments: inputs.globalEnvironments,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-pixi",
-  "version": "0.9.6",
+  "version": "0.10.0",
   "private": true,
   "description": "Action to set up the pixi package manager.",
   "scripts": {

--- a/src/options.ts
+++ b/src/options.ts
@@ -390,7 +390,7 @@ const inferOptions = (inputs: Inputs): Options => {
                 s3SessionToken: inputs.authS3SessionToken,
                 persistCredentials: persistCredentials
               }) as Auth)
-  const postCleanup = inputs.postCleanup ?? true
+  const postCleanup = inputs.postCleanup ?? false
   const pypiKeyringProvider = inputs.pypiKeyringProvider
   return {
     globalEnvironments: inputs.globalEnvironments,


### PR DESCRIPTION
Especially on Windows this sometimes goes wrong.
On other platforms it also often doesn't make sense since runners are ephemeral. Disabling that might even speed things up

If updating documentation:

- [x] Updated documentation in https://github.com/prefix-dev/pixi/blob/main/docs/integration/ci/github_actions.md as well https://github.com/prefix-dev/pixi/pull/6465
 